### PR TITLE
Lock msg type

### DIFF
--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -1,4 +1,46 @@
-//! register rules
+//! register validator
+//! ## This is an example:
+//!
+//! ```rust
+//! # use serde::{Deserialize, Serialize};
+//! # use valitron::{
+//! # available::{Required, StartWith},
+//! # custom, Message, RuleExt, Validator
+//! # };
+//! #[derive(Serialize, Debug)]
+//! struct Person {
+//!     introduce: &'static str,
+//!     age: u8,
+//!     weight: f32,
+//! }
+//!
+//! # fn main() {
+//! let validator = Validator::new()
+//!     .rule("introduce", Required.and(StartWith("I am")))
+//!     .rule("age", custom(age_range))
+//!     .message([
+//!         ("introduce.required", "introduce is required"),
+//!         ("introduce.start_with", "introduce should be starts with `I am`"),
+//!     ]);
+//!
+//! let person = Person {
+//!     introduce: "hi",
+//!     age: 18,
+//!     weight: 20.0,
+//! };
+//!
+//! let res = validator.validate(person).unwrap_err();
+//! assert!(res.len() == 2);
+//! # }
+//!
+//! fn age_range(age: &mut u8) -> Result<(), &'static str> {
+//!     if *age >= 25 && *age <= 45 {
+//!         Ok(())
+//!     } else {
+//!         Err("age should be between 25 and 45")
+//!     }
+//! }
+//! ```
 
 use std::{
     collections::{
@@ -23,6 +65,7 @@ use serde::{Deserialize, Serialize};
 mod field_name;
 mod lexer;
 
+/// register a validator
 #[derive(Default)]
 pub struct Validator {
     rules: HashMap<FieldNames, RuleList>,
@@ -229,7 +272,7 @@ impl Validator {
     }
 }
 
-/// validateable on any types
+/// validateable for any types
 pub trait Validatable {
     /// if not change value
     fn validate(&self, validator: Validator) -> Result<(), ValidatorError>;
@@ -256,6 +299,7 @@ where
     }
 }
 
+/// store validate error message
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatorError {
     message: HashMap<FieldNames, Vec<Message>>,

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -112,10 +112,10 @@ mod tests {
 
     use super::{super::Required, Range};
 
-    fn register<R: IntoRuleList>(_: R) {}
+    fn register<R: IntoRuleList<M>, M>(_: R) {}
 
     #[test]
     fn test_register() {
-        register(Required.and(Range::new(1..10)));
+        //register::<_, String>(Required.and(Range::new(1..10)));
     }
 }

--- a/src/rule/boxed.rs
+++ b/src/rule/boxed.rs
@@ -4,15 +4,16 @@ use crate::value::ValueMap;
 
 use super::{IntoRuleMessage, Message, Rule};
 
-pub struct ErasedRule(pub(super) Box<dyn BoxedRule>);
+pub struct ErasedRule<M>(pub(super) Box<dyn BoxedRule>, PhantomData<M>);
 
-impl ErasedRule {
-    pub fn new<H, M>(handler: H) -> Self
+impl<M> ErasedRule<M> {
+    pub fn new<H, S>(handler: H) -> Self
     where
-        H: Rule<M>,
-        M: 'static,
+        H: Rule<S, Message = M>,
+        S: 'static,
+        M: IntoRuleMessage + 'static,
     {
-        Self(Box::new(handler.into_boxed()))
+        Self(Box::new(handler.into_boxed()), PhantomData)
     }
 
     pub fn name(&self) -> &'static str {
@@ -23,9 +24,9 @@ impl ErasedRule {
     }
 }
 
-impl Clone for ErasedRule {
+impl<M> Clone for ErasedRule<M> {
     fn clone(&self) -> Self {
-        Self(self.0.clone_box())
+        Self(self.0.clone_box(), PhantomData)
     }
 }
 

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -1,4 +1,26 @@
 //! define Rule trait, inner rule type
+//! # A custom rule example
+//! ```rust
+//! # use valitron::{Value, RuleShortcut};
+//! #[derive(Clone)]
+//! struct Gt10;
+//!
+//! impl RuleShortcut for Gt10 {
+//!     type Message = &'static str;
+//!
+//!     fn name(&self) -> &'static str {
+//!         "gt10"
+//!     }
+//!
+//!     fn message(&self) -> Self::Message {
+//!         "the number should be greater than 10"
+//!     }
+//!
+//!     fn call(&mut self, data: &mut Value) -> bool {
+//!         data > 10_u8
+//!     }
+//! }
+//! ```
 
 use std::slice::Iter;
 
@@ -21,17 +43,21 @@ mod test;
 /// ```rust
 /// # use valitron::{Rule, ValueMap};
 /// #[derive(Clone)]
-/// struct HelloWorld;
+/// struct Gt10;
 ///
-/// impl Rule<()> for HelloWorld {
-///     type Message = String;
+/// impl Rule<()> for Gt10 {
+///     type Message = &'static str;
 ///
 ///     fn name(&self) -> &'static str {
-///         "hello"
+///         "gt10"
 ///     }
 ///
 ///     fn call(&mut self, data: &mut ValueMap) -> Result<(), Self::Message> {
-///         Ok(())
+///         if data.current().unwrap() > &10 {
+///             Ok(())
+///         } else {
+///             Err("the number should be greater than 10")
+///         }
 ///     }
 /// }
 /// ```
@@ -325,6 +351,7 @@ pub trait IntoRuleList {
     fn into_list(self) -> RuleList;
 }
 
+/// load closure rule
 pub fn custom<F, V, M>(f: F) -> RuleList
 where
     F: for<'a> FnOnce(&'a mut V) -> Result<(), M> + 'static + Clone,

--- a/src/value/cmp.rs
+++ b/src/value/cmp.rs
@@ -159,16 +159,6 @@ impl PartialEq<Value> for f32 {
     }
 }
 
-impl PartialEq<Value> for f64 {
-    fn eq(&self, other: &Value) -> bool {
-        if let Value::Float64(Float64(f)) = other {
-            self == f
-        } else {
-            false
-        }
-    }
-}
-
 impl PartialEq<f32> for Value {
     fn eq(&self, other: &f32) -> bool {
         if let Value::Float32(Float32(f)) = self {
@@ -179,7 +169,96 @@ impl PartialEq<f32> for Value {
     }
 }
 
+impl PartialEq<&Value> for f32 {
+    fn eq(&self, other: &&Value) -> bool {
+        if let Value::Float32(Float32(f)) = other {
+            self == f
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialEq<f32> for &Value {
+    fn eq(&self, other: &f32) -> bool {
+        if let Value::Float32(Float32(f)) = self {
+            f == other
+        } else {
+            false
+        }
+    }
+}
+impl PartialEq<&mut Value> for f32 {
+    fn eq(&self, other: &&mut Value) -> bool {
+        if let Value::Float32(Float32(f)) = other {
+            self == f
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialEq<f32> for &mut Value {
+    fn eq(&self, other: &f32) -> bool {
+        if let Value::Float32(Float32(f)) = self {
+            f == other
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialEq<Value> for f64 {
+    fn eq(&self, other: &Value) -> bool {
+        if let Value::Float64(Float64(f)) = other {
+            self == f
+        } else {
+            false
+        }
+    }
+}
+
 impl PartialEq<f64> for Value {
+    fn eq(&self, other: &f64) -> bool {
+        if let Value::Float64(Float64(f)) = self {
+            f == other
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialEq<&Value> for f64 {
+    fn eq(&self, other: &&Value) -> bool {
+        if let Value::Float64(Float64(f)) = other {
+            self == f
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialEq<f64> for &Value {
+    fn eq(&self, other: &f64) -> bool {
+        if let Value::Float64(Float64(f)) = self {
+            f == other
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialEq<&mut Value> for f64 {
+    fn eq(&self, other: &&mut Value) -> bool {
+        if let Value::Float64(Float64(f)) = other {
+            self == f
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialEq<f64> for &mut Value {
     fn eq(&self, other: &f64) -> bool {
         if let Value::Float64(Float64(f)) = self {
             f == other

--- a/src/value/cmp.rs
+++ b/src/value/cmp.rs
@@ -25,6 +25,44 @@ macro_rules! primitive_eq {
                 }
             }
         }
+
+        impl PartialEq<&Value> for $ty {
+            fn eq(&self, other: &&Value) -> bool {
+                if let Value::$val(n) = other {
+                    self == n
+                } else {
+                    false
+                }
+            }
+        }
+        impl PartialEq<$ty> for &Value {
+            fn eq(&self, other: &$ty) -> bool {
+                if let Value::$val(n) = self {
+                    n == other
+                } else {
+                    false
+                }
+            }
+        }
+
+        impl PartialEq<&mut Value> for $ty {
+            fn eq(&self, other: &&mut Value) -> bool {
+                if let Value::$val(n) = other {
+                    self == n
+                } else {
+                    false
+                }
+            }
+        }
+        impl PartialEq<$ty> for &mut Value {
+            fn eq(&self, other: &$ty) -> bool {
+                if let Value::$val(n) = self {
+                    n == other
+                } else {
+                    false
+                }
+            }
+        }
     };
 }
 
@@ -40,6 +78,44 @@ macro_rules! primitive_ord {
             }
         }
         impl PartialOrd<$ty> for Value {
+            fn partial_cmp(&self, other: &$ty) -> Option<Ordering> {
+                if let Value::$val(n) = self {
+                    n.partial_cmp(other)
+                } else {
+                    None
+                }
+            }
+        }
+
+        impl PartialOrd<&Value> for $ty {
+            fn partial_cmp(&self, other: &&Value) -> Option<Ordering> {
+                if let Value::$val(n) = other {
+                    self.partial_cmp(n)
+                } else {
+                    None
+                }
+            }
+        }
+        impl PartialOrd<$ty> for &Value {
+            fn partial_cmp(&self, other: &$ty) -> Option<Ordering> {
+                if let Value::$val(n) = self {
+                    n.partial_cmp(other)
+                } else {
+                    None
+                }
+            }
+        }
+
+        impl PartialOrd<&mut Value> for $ty {
+            fn partial_cmp(&self, other: &&mut Value) -> Option<Ordering> {
+                if let Value::$val(n) = other {
+                    self.partial_cmp(n)
+                } else {
+                    None
+                }
+            }
+        }
+        impl PartialOrd<$ty> for &mut Value {
             fn partial_cmp(&self, other: &$ty) -> Option<Ordering> {
                 if let Value::$val(n) = self {
                     n.partial_cmp(other)
@@ -111,4 +187,16 @@ impl PartialEq<f64> for Value {
             false
         }
     }
+}
+
+#[test]
+fn all() {
+    let mut value = Value::Uint8(10);
+
+    assert!(value == 10_u8);
+    assert!(value > 9_u8);
+    assert!(&value == 10_u8);
+    assert!(&value > 9_u8);
+    assert!(&mut value == 10_u8);
+    assert!(&mut value > 9_u8);
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -11,10 +11,13 @@
 //! ```
 //! # use valitron::Value;
 //! # fn main() {
-//! assert!(Value::Uint8(9) == 9_u8);
-//! assert!(10_u8 == Value::Uint8(10));
-//! assert_eq!(Value::Uint8(10) > 9_u8, true);
-//! assert_eq!(9_u8 < Value::Uint8(10), true);
+//! let mut value = Value::Uint8(10);
+//! assert!(value == 10_u8);
+//! assert!(value > 9_u8);
+//! assert!(&value == 10_u8);
+//! assert!(&value > 9_u8);
+//! assert!(&mut value == 10_u8);
+//! assert!(&mut value > 9_u8);
 //! # }
 //! ```
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -25,7 +25,14 @@ use crate::register::{FieldName, FieldNames, Parser};
 mod cmp;
 mod float;
 
-/// seralized resultant
+/// # serialized resultant
+///
+/// All rust types will be serialized into this, contains nested structures.
+///
+/// This is [`Rule`], [`RuleShortcut`] implementation's basis.
+///
+/// [`Rule`]: crate::rule::Rule
+/// [`RuleShortcut`]: crate::rule::RuleShortcut
 #[derive(Debug, PartialEq, Eq, Clone, Ord, PartialOrd)]
 pub enum Value {
     Uint8(u8),
@@ -106,6 +113,8 @@ impl ValueMap {
             index: FieldNames::default(),
         }
     }
+
+    /// change index
     pub fn index(&mut self, index: FieldNames) {
         self.index = index;
     }
@@ -228,6 +237,34 @@ impl Value {
                 | Self::Unit
                 | Self::String(_)
         )
+    }
+
+    pub fn f32(&self) -> Option<&f32> {
+        match self {
+            Value::Float32(float::Float32(f)) => Some(f),
+            _ => None,
+        }
+    }
+
+    pub fn f32_mut(&mut self) -> Option<&mut f32> {
+        match self {
+            Value::Float32(float::Float32(f)) => Some(f),
+            _ => None,
+        }
+    }
+
+    pub fn f64(&self) -> Option<&f64> {
+        match self {
+            Value::Float64(float::Float64(f)) => Some(f),
+            _ => None,
+        }
+    }
+
+    pub fn f64_mut(&mut self) -> Option<&mut f64> {
+        match self {
+            Value::Float64(float::Float64(f)) => Some(f),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
# Intention

There are currently three types of message available:
- u8
- String
- both

`ValidatorError` is implemented `Serialize` ,when it covert to json, probability result:

- `{"field1":["message1","message2"]}`
- `{"field1":["message1",2]}`
- `{"field1":[1,2]}`

second result is type error.