### PR TITLE
lock validate message type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,13 @@ required-features = ["full"]
 name = "rocket"
 required-features = ["full"]
 
+[[example]]
+name = "enum_msg"
+
+[[example]]
+name = "enum_msg_full"
+required-features = ["full"]
+
 [dependencies]
 serde = { version = "^1.0" }
 

--- a/examples/enum_msg.rs
+++ b/examples/enum_msg.rs
@@ -1,0 +1,49 @@
+//! usage without "full" feature
+
+use valitron::{RuleExt, RuleShortcut, Validator, Value};
+
+fn main() {
+    let _validator = Validator::<MyMessage>::new()
+        .rule("num", Gt10.and(Lt20))
+        .message([("num.gt10", MyMessage::Gt10), ("num.lt20", MyMessage::Lt20)]);
+}
+
+#[derive(Clone, Default)]
+enum MyMessage {
+    #[default]
+    NameRequierd,
+    Gt10,
+    Lt20,
+}
+
+#[derive(Clone)]
+struct Gt10;
+
+impl RuleShortcut for Gt10 {
+    type Message = MyMessage;
+    fn name(&self) -> &'static str {
+        "gt10"
+    }
+    fn message(&self) -> Self::Message {
+        MyMessage::Gt10
+    }
+    fn call(&mut self, data: &mut Value) -> bool {
+        data > 10_u8
+    }
+}
+
+#[derive(Clone)]
+struct Lt20;
+
+impl RuleShortcut for Lt20 {
+    type Message = MyMessage;
+    fn name(&self) -> &'static str {
+        "gt10"
+    }
+    fn message(&self) -> Self::Message {
+        MyMessage::Lt20
+    }
+    fn call(&mut self, data: &mut Value) -> bool {
+        data < 20_u8
+    }
+}

--- a/examples/enum_msg_full.rs
+++ b/examples/enum_msg_full.rs
@@ -1,26 +1,55 @@
 use valitron::{
     available::{Message, Required, StartWith},
-    RuleExt, Validator,
+    RuleExt, RuleShortcut, Validator, Value,
 };
 
 fn main() {
     let _validator = Validator::<MyMessage>::new()
-        .rule("name", Required.and(StartWith("foo")))
+        .rule("name", Required.and(StartWith("foo")).and(Gt10))
         .message([
             ("name.required", MyMessage::NameRequierd),
             ("name.start_with", MyMessage::NameStartWith),
         ]);
 }
 
+const GT_10_MESSAGE: &str = "gt10";
+
 #[derive(Clone)]
 enum MyMessage {
     NameRequierd,
     NameStartWith,
+    Gt10,
     Undefined,
 }
 
 impl From<Message> for MyMessage {
-    fn from(_value: Message) -> Self {
-        Self::Undefined
+    fn from(value: Message) -> Self {
+        if value.as_str() == GT_10_MESSAGE {
+            Self::Gt10
+        } else {
+            Self::Undefined
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Gt10;
+
+impl RuleShortcut for Gt10 {
+    type Message = Message;
+
+    fn name(&self) -> &'static str {
+        "gt10"
+    }
+
+    fn message(&self) -> Self::Message {
+        Message::new(
+            valitron::available::MessageKind::Undefined,
+            GT_10_MESSAGE.into(),
+        )
+    }
+
+    fn call(&mut self, data: &mut Value) -> bool {
+        data > 10_u8
     }
 }

--- a/examples/enum_msg_full.rs
+++ b/examples/enum_msg_full.rs
@@ -1,0 +1,26 @@
+use valitron::{
+    available::{Message, Required, StartWith},
+    RuleExt, Validator,
+};
+
+fn main() {
+    let _validator = Validator::<MyMessage>::new()
+        .rule("name", Required.and(StartWith("foo")))
+        .message([
+            ("name.required", MyMessage::NameRequierd),
+            ("name.start_with", MyMessage::NameStartWith),
+        ]);
+}
+
+#[derive(Clone)]
+enum MyMessage {
+    NameRequierd,
+    NameStartWith,
+    Undefined,
+}
+
+impl From<Message> for MyMessage {
+    fn from(_value: Message) -> Self {
+        Self::Undefined
+    }
+}

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -20,7 +20,7 @@ extern crate rocket;
 
 #[get("/?<name>&<second>")]
 fn index(name: String, second: String) -> String {
-    match (name, second).validate_mut(Validator::new().rule("0", Trim.and(Required))) {
+    match (name, second).validate_mut(Validator::<String>::new().rule("0", Trim.and(Required))) {
         Ok((name, _)) => format!("Hello, {name}!"),
         Err(_) => format!("name is required"),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,11 +34,11 @@
 //! assert!(res.len() == 2);
 //! # }
 //!
-//! fn age_range(age: &mut u8) -> Result<(), &'static str> {
+//! fn age_range(age: &mut u8) -> Result<(), String> {
 //!     if *age >= 25 && *age <= 45 {
 //!         Ok(())
 //!     } else {
-//!         Err("age should be between 25 and 45")
+//!         Err("age should be between 25 and 45".into())
 //!     }
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! }
 //!
 //! # fn main() {
-//! let validator = Validator::new()
+//! let validator = Validator::<String>::new()
 //!     .rule("introduce", Required.and(StartWith("I am")))
 //!     .rule("age", custom(age_range))
 //!     .message([

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! # use serde::{Deserialize, Serialize};
 //! # use valitron::{
 //! # available::{Required, StartWith},
-//! # custom, Message, RuleExt, Validator
+//! # custom, RuleExt, Validator
 //! # };
 //! #[derive(Serialize, Debug)]
 //! struct Person {
@@ -96,7 +96,7 @@ mod ser;
 pub mod value;
 
 pub use register::{Validatable, Validator};
-pub use rule::{custom, IntoRuleMessage, Message, Rule, RuleExt, RuleShortcut};
+pub use rule::{custom, Rule, RuleExt, RuleShortcut};
 pub use value::{FromValue, Value, ValueMap};
 
 #[cfg(feature = "full")]

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -81,12 +81,12 @@ macro_rules! panic_on_err {
     };
 }
 
-impl<M> Validator<M>
-where
-    M: Default,
-{
+impl<M> Validator<M> {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            rules: HashMap::new(),
+            message: HashMap::new(),
+        }
     }
 }
 

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -178,9 +178,10 @@ where
     /// # Panic
     ///
     /// When field or rule is not existing ,this will panic
-    pub fn message<'key, const N: usize>(mut self, list: [(&'key str, M); N]) -> Self
+    pub fn message<'key, const N: usize, MSG>(mut self, list: [(&'key str, MSG); N]) -> Self
     where
         M: IntoRuleMessage,
+        MSG: Into<M>,
     {
         self.message = HashMap::from_iter(
             list.map(|(key_str, v)| {
@@ -188,7 +189,7 @@ where
 
                 panic_on_err!(self.exit_message(&msg_key));
 
-                (msg_key, v.into_message())
+                (msg_key, v.into().into_message())
             })
             .into_iter(),
         );

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -1,46 +1,4 @@
 //! register validator
-//! ## This is an example:
-//!
-//! ```rust
-//! # use serde::{Deserialize, Serialize};
-//! # use valitron::{
-//! # available::{Required, StartWith},
-//! # custom, RuleExt, Validator
-//! # };
-//! #[derive(Serialize, Debug)]
-//! struct Person {
-//!     introduce: &'static str,
-//!     age: u8,
-//!     weight: f32,
-//! }
-//!
-//! # fn main() {
-//! let validator = Validator::new()
-//!     .rule("introduce", Required.and(StartWith("I am")))
-//!     .rule("age", custom(age_range))
-//!     .message([
-//!         ("introduce.required", "introduce is required"),
-//!         ("introduce.start_with", "introduce should be starts with `I am`"),
-//!     ]);
-//!
-//! let person = Person {
-//!     introduce: "hi",
-//!     age: 18,
-//!     weight: 20.0,
-//! };
-//!
-//! let res = validator.validate(person).unwrap_err();
-//! assert!(res.len() == 2);
-//! # }
-//!
-//! fn age_range(age: &mut u8) -> Result<(), String> {
-//!     if *age >= 25 && *age <= 45 {
-//!         Ok(())
-//!     } else {
-//!         Err("age should be between 25 and 45".into())
-//!     }
-//! }
-//! ```
 
 use std::{
     collections::{
@@ -68,6 +26,7 @@ mod field_name;
 mod lexer;
 
 /// register a validator
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 #[derive(Default)]
 #[cfg(feature = "full")]
 pub struct Validator<M1, M = Message> {
@@ -76,6 +35,49 @@ pub struct Validator<M1, M = Message> {
 }
 
 /// register a validator
+/// ## This is an example:
+///
+/// ```rust
+/// # use serde::{Deserialize, Serialize};
+/// # use valitron::{
+/// # available::{Required, StartWith},
+/// # custom, RuleExt, Validator
+/// # };
+/// #[derive(Serialize, Debug)]
+/// struct Person {
+///     introduce: &'static str,
+///     age: u8,
+///     weight: f32,
+/// }
+///
+/// # fn main() {
+/// let validator = Validator::new()
+///     .rule("introduce", Required.and(StartWith("I am")))
+///     .rule("age", custom(age_range))
+///     .message([
+///         ("introduce.required", "introduce is required"),
+///         ("introduce.start_with", "introduce should be starts with `I am`"),
+///     ]);
+///
+/// let person = Person {
+///     introduce: "hi",
+///     age: 18,
+///     weight: 20.0,
+/// };
+///
+/// let res = validator.validate(person).unwrap_err();
+/// assert!(res.len() == 2);
+/// # }
+///
+/// fn age_range(age: &mut u8) -> Result<(), String> {
+///     if *age >= 25 && *age <= 45 {
+///         Ok(())
+///     } else {
+///         Err("age should be between 25 and 45".into())
+///     }
+/// }
+/// ```
+#[cfg_attr(docsrs, doc(cfg(not(feature = "full"))))]
 #[derive(Default)]
 #[cfg(not(feature = "full"))]
 pub struct Validator<M = String> {

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -33,11 +33,11 @@
 //! assert!(res.len() == 2);
 //! # }
 //!
-//! fn age_range(age: &mut u8) -> Result<(), &'static str> {
+//! fn age_range(age: &mut u8) -> Result<(), String> {
 //!     if *age >= 25 && *age <= 45 {
 //!         Ok(())
 //!     } else {
-//!         Err("age should be between 25 and 45")
+//!         Err("age should be between 25 and 45".into())
 //!     }
 //! }
 //! ```

--- a/src/rule/available/confirm.rs
+++ b/src/rule/available/confirm.rs
@@ -4,6 +4,8 @@ use std::fmt::Display;
 
 use crate::{register::FieldNames, value::ValueMap, RuleShortcut, Value};
 
+use super::{Message, MessageKind};
+
 #[derive(Clone)]
 pub struct Confirm<T>(pub T);
 
@@ -30,13 +32,16 @@ impl<T> Confirm<T>
 where
     T: Display,
 {
-    fn message_in(&self) -> String {
-        format!("this field value must be equal to `{}` field", self.0)
+    fn message_in(&self) -> Message {
+        Message::new(
+            MessageKind::Confirm,
+            format!("this field value must be equal to `{}` field", self.0),
+        )
     }
 }
 
 impl RuleShortcut for Confirm<String> {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         self.name_in()
@@ -58,7 +63,7 @@ impl RuleShortcut for Confirm<String> {
 }
 
 impl RuleShortcut for Confirm<&str> {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         self.name_in()

--- a/src/rule/available/mod.rs
+++ b/src/rule/available/mod.rs
@@ -9,5 +9,103 @@ pub mod trim;
 pub use confirm::Confirm;
 pub use range::Range;
 pub use required::Required;
+use serde::{ser::SerializeMap, Serialize};
 pub use start_with::StartWith;
 pub use trim::Trim;
+
+/// Error message returned when validate fail
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct Message {
+    kind: MessageKind,
+    content: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub enum MessageKind {
+    Required,
+    Confirm,
+    StartWith,
+    Trim,
+    Range,
+
+    #[default]
+    Undefined,
+}
+
+impl Message {
+    pub fn new(kind: MessageKind, content: String) -> Self {
+        Message { kind, content }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.content
+    }
+
+    pub fn kind(&self) -> &MessageKind {
+        &self.kind
+    }
+}
+
+impl From<Message> for String {
+    fn from(msg: Message) -> Self {
+        msg.content
+    }
+}
+impl From<String> for Message {
+    fn from(content: String) -> Self {
+        Self {
+            kind: MessageKind::Undefined,
+            content,
+        }
+    }
+}
+
+impl Serialize for Message {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // if self.kind != 0 && !self.content.is_empty() {
+        //     let mut map = serializer.serialize_map(Some(2))?;
+        //     map.serialize_entry("code", &self.code)?;
+        //     map.serialize_entry("content", &self.content)?;
+        //     map.end()
+        // } else if self.code != 0 {
+        //     serializer.serialize_u8(self.code)
+        // } else {
+
+        // }
+        serializer.serialize_str(&self.content)
+    }
+}
+
+impl PartialEq<Message> for String {
+    fn eq(&self, other: &Message) -> bool {
+        self == &other.content
+    }
+}
+
+pub trait FromRuleMessage {
+    fn from_message(msg: Message) -> Self;
+}
+
+impl FromRuleMessage for Message {
+    fn from_message(msg: Message) -> Self {
+        msg
+    }
+}
+
+// #[test]
+// fn test_message_serialize() {
+//     let msg = Message::new(10, "hello world".into());
+//     let json = serde_json::to_string(&msg).unwrap();
+//     assert_eq!(json, r#"{"code":10,"content":"hello world"}"#);
+
+//     let msg = Message::from_code(10);
+//     let json = serde_json::to_string(&msg).unwrap();
+//     assert_eq!(json, "10");
+
+//     let msg = Message::from_content("hello".into());
+//     let json = serde_json::to_string(&msg).unwrap();
+//     assert_eq!(json, r#""hello""#);
+// }

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -4,7 +4,7 @@
 //! ```
 //! # use valitron::{Validator, available::Range};
 //! # fn main() {
-//! let validator = Validator::new()
+//! let validator = Validator::<String>::new()
 //!     .rule("num", Range::new(10..20));
 //! # }
 //! ```

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -112,10 +112,10 @@ mod tests {
 
     use super::{super::Required, Range};
 
-    fn register<R: IntoRuleList>(_: R) {}
+    fn register<R: IntoRuleList<M>, M>(_: R) {}
 
     #[test]
     fn test_register() {
-        register(Required.and(Range::new(1..10)));
+        //register::<_, String>(Required.and(Range::new(1..10)));
     }
 }

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -11,6 +11,7 @@
 
 use std::{marker::PhantomData, ops::RangeBounds};
 
+use super::Message;
 use crate::{RuleShortcut, Value};
 
 #[derive(Clone)]
@@ -30,8 +31,11 @@ impl<T, Num> Range<T, Num> {
     fn name_in(&self) -> &'static str {
         "range"
     }
-    fn message_in(&self) -> String {
-        "the value not in the range".into()
+    fn message_in(&self) -> Message {
+        Message::new(
+            super::MessageKind::Range,
+            "the value not in the range".into(),
+        )
     }
 }
 
@@ -41,7 +45,7 @@ macro_rules! impl_range {
         where
             T: RangeBounds<$ty> + Clone + 'static,
         {
-            type Message = String;
+            type Message = Message;
             fn name(&self) -> &'static str {
                 self.name_in()
             }
@@ -72,7 +76,7 @@ impl<T> RuleShortcut for Range<T, f32>
 where
     T: RangeBounds<f32> + Clone + 'static,
 {
-    type Message = String;
+    type Message = Message;
     fn name(&self) -> &'static str {
         self.name_in()
     }
@@ -91,7 +95,7 @@ impl<T> RuleShortcut for Range<T, f64>
 where
     T: RangeBounds<f64> + Clone + 'static,
 {
-    type Message = String;
+    type Message = Message;
     fn name(&self) -> &'static str {
         self.name_in()
     }

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -30,8 +30,8 @@ impl<T, Num> Range<T, Num> {
     fn name_in(&self) -> &'static str {
         "range"
     }
-    fn message_in(&self) -> &'static str {
-        "the value not in the range"
+    fn message_in(&self) -> String {
+        "the value not in the range".into()
     }
 }
 
@@ -41,7 +41,7 @@ macro_rules! impl_range {
         where
             T: RangeBounds<$ty> + Clone + 'static,
         {
-            type Message = &'static str;
+            type Message = String;
             fn name(&self) -> &'static str {
                 self.name_in()
             }
@@ -72,7 +72,7 @@ impl<T> RuleShortcut for Range<T, f32>
 where
     T: RangeBounds<f32> + Clone + 'static,
 {
-    type Message = &'static str;
+    type Message = String;
     fn name(&self) -> &'static str {
         self.name_in()
     }
@@ -91,7 +91,7 @@ impl<T> RuleShortcut for Range<T, f64>
 where
     T: RangeBounds<f64> + Clone + 'static,
 {
-    type Message = &'static str;
+    type Message = String;
     fn name(&self) -> &'static str {
         self.name_in()
     }

--- a/src/rule/available/required.rs
+++ b/src/rule/available/required.rs
@@ -1,18 +1,22 @@
 //! Value can not be empty
 
+use super::Message;
 use crate::{RuleShortcut, Value};
 
 #[derive(Clone, Debug)]
 pub struct Required;
 
 impl RuleShortcut for Required {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         "required"
     }
     fn message(&self) -> Self::Message {
-        "this field is required".into()
+        Message::new(
+            super::MessageKind::Required,
+            "this field is required".into(),
+        )
     }
 
     fn call(&mut self, value: &mut Value) -> bool {

--- a/src/rule/available/required.rs
+++ b/src/rule/available/required.rs
@@ -6,13 +6,13 @@ use crate::{RuleShortcut, Value};
 pub struct Required;
 
 impl RuleShortcut for Required {
-    type Message = &'static str;
+    type Message = String;
 
     fn name(&self) -> &'static str {
         "required"
     }
     fn message(&self) -> Self::Message {
-        "this field is required"
+        "this field is required".into()
     }
 
     fn call(&mut self, value: &mut Value) -> bool {

--- a/src/rule/available/start_with.rs
+++ b/src/rule/available/start_with.rs
@@ -4,6 +4,8 @@ use std::fmt::Display;
 
 use crate::{RuleShortcut, Value};
 
+use super::Message;
+
 #[derive(Clone, Debug)]
 pub struct StartWith<T>(pub T);
 
@@ -17,13 +19,16 @@ impl<T> StartWith<T>
 where
     T: Display,
 {
-    fn message_in(&self) -> String {
-        format!("this field must be start with `{}`", self.0)
+    fn message_in(&self) -> Message {
+        Message::new(
+            super::MessageKind::StartWith,
+            format!("this field must be start with `{}`", self.0),
+        )
     }
 }
 
 impl RuleShortcut for StartWith<&str> {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         self.name_in()
@@ -40,7 +45,7 @@ impl RuleShortcut for StartWith<&str> {
 }
 
 impl RuleShortcut for StartWith<char> {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         self.name_in()

--- a/src/rule/available/trim.rs
+++ b/src/rule/available/trim.rs
@@ -1,12 +1,12 @@
 //! Modifies a string by leading and trailing whitespace removed
 
-use crate::{Message, RuleShortcut, Value};
+use crate::{RuleShortcut, Value};
 
 #[derive(Clone)]
 pub struct Trim;
 
 impl RuleShortcut for Trim {
-    type Message = Message;
+    type Message = String;
 
     fn call(&mut self, data: &mut crate::Value) -> bool {
         match data {
@@ -18,7 +18,7 @@ impl RuleShortcut for Trim {
     }
 
     fn message(&self) -> Self::Message {
-        Message::default()
+        String::default()
     }
 
     fn name(&self) -> &'static str {

--- a/src/rule/available/trim.rs
+++ b/src/rule/available/trim.rs
@@ -2,11 +2,13 @@
 
 use crate::{RuleShortcut, Value};
 
+use super::Message;
+
 #[derive(Clone)]
 pub struct Trim;
 
 impl RuleShortcut for Trim {
-    type Message = String;
+    type Message = Message;
 
     fn call(&mut self, data: &mut crate::Value) -> bool {
         match data {
@@ -18,7 +20,7 @@ impl RuleShortcut for Trim {
     }
 
     fn message(&self) -> Self::Message {
-        String::default()
+        Message::default()
     }
 
     fn name(&self) -> &'static str {

--- a/src/rule/available/trim.rs
+++ b/src/rule/available/trim.rs
@@ -20,7 +20,7 @@ impl RuleShortcut for Trim {
     }
 
     fn message(&self) -> Self::Message {
-        Message::default()
+        Message::new(super::MessageKind::Trim, String::new())
     }
 
     fn name(&self) -> &'static str {

--- a/src/rule/boxed.rs
+++ b/src/rule/boxed.rs
@@ -4,15 +4,16 @@ use crate::value::ValueMap;
 
 use super::{IntoRuleMessage, Message, Rule};
 
-pub struct ErasedRule(pub(super) Box<dyn BoxedRule>);
+pub struct ErasedRule<M>(pub(super) Box<dyn BoxedRule>, PhantomData<M>);
 
-impl ErasedRule {
-    pub fn new<H, M>(handler: H) -> Self
+impl<M> ErasedRule<M> {
+    pub fn new<H, S>(handler: H) -> Self
     where
-        H: Rule<M>,
-        M: 'static,
+        H: Rule<S, Message = M>,
+        S: 'static,
+        M: IntoRuleMessage + 'static,
     {
-        Self(Box::new(handler.into_boxed()))
+        Self(Box::new(handler.into_boxed()), PhantomData)
     }
 
     pub fn name(&self) -> &'static str {
@@ -23,9 +24,9 @@ impl ErasedRule {
     }
 }
 
-impl Clone for ErasedRule {
+impl<M> Clone for ErasedRule<M> {
     fn clone(&self) -> Self {
-        Self(self.0.clone_box())
+        Self(self.0.clone_box(), PhantomData)
     }
 }
 

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -388,42 +388,59 @@ where
     }
 }
 
-// #[cfg(all(test, feature = "full"))]
-// mod test_regster {
-//     use super::available::*;
-//     use super::*;
-//     fn register<R: IntoRuleList<M>, M>(_: R) {}
+#[cfg(all(test, feature = "full"))]
+mod test_regster {
+    use super::available::*;
+    use super::*;
+    fn register<R: IntoRuleList<M>, M>(_: R) {}
 
-//     fn hander(_val: &mut ValueMap) -> Result<(), String> {
-//         Ok(())
-//     }
-//     fn hander2(_val: &mut Value) -> Result<(), String> {
-//         Ok(())
-//     }
+    fn hander(_val: &mut ValueMap) -> Result<(), String> {
+        Ok(())
+    }
+    fn hander2(_val: &mut Value) -> Result<(), String> {
+        Ok(())
+    }
 
-//     #[test]
-//     fn test() {
-//         register(Required);
-//         register(Required.custom(hander2));
-//         register(Required.custom(hander));
-//         register(Required.and(StartWith("foo")));
-//         register(Required.and(StartWith("foo")).bail());
-//         register(Required.and(StartWith("foo")).custom(hander2).bail());
-//         register(
-//             Required
-//                 .and(StartWith("foo"))
-//                 .custom(hander2)
-//                 .custom(hander)
-//                 .bail(),
-//         );
-//         register(custom(hander2));
-//         register(custom(hander));
-//         register(custom(hander).and(StartWith("foo")));
-//         register(custom(hander).and(StartWith("foo")).bail());
-//         register(custom(|_a: &mut u8| Ok::<_, u8>(())));
-//         register(custom(|_a: &mut u8| Ok::<_, u8>(())));
-//     }
-// }
+    #[derive(Clone)]
+    struct Gt10;
+
+    impl RuleShortcut for Gt10 {
+        type Message = u8;
+        fn name(&self) -> &'static str {
+            "gt10"
+        }
+        fn message(&self) -> Self::Message {
+            1
+        }
+        fn call(&mut self, data: &mut Value) -> bool {
+            data > 10_u8
+        }
+    }
+
+    #[test]
+    fn test() {
+        register(Required);
+        register(Required.custom(hander2));
+        register(Required.custom(hander));
+        register(Required.and(StartWith("foo")));
+        register(Required.and(StartWith("foo")).bail());
+        register(Required.and(StartWith("foo")).custom(hander2).bail());
+        register(
+            Required
+                .and(StartWith("foo"))
+                .custom(hander2)
+                .custom(hander)
+                .bail(),
+        );
+        register(custom(hander2));
+        register(custom(hander));
+        register(custom(hander).and(StartWith("foo")));
+        register(custom(hander).and(StartWith("foo")).bail());
+        register(custom(|_a: &mut u8| Ok::<_, u8>(())).and(Gt10));
+        register(Gt10.custom(|_a: &mut u8| Ok::<_, u8>(())));
+        register(custom(|_a: &mut u8| Ok::<_, u8>(())));
+    }
+}
 
 /// used by convenient implementation custom rules.
 pub trait RuleShortcut {

--- a/src/rule/test.rs
+++ b/src/rule/test.rs
@@ -1,16 +1,1 @@
-use super::Message;
 
-#[test]
-fn test_message_serialize() {
-    let msg = Message::new(10, "hello world".into());
-    let json = serde_json::to_string(&msg).unwrap();
-    assert_eq!(json, r#"{"code":10,"content":"hello world"}"#);
-
-    let msg = Message::from_code(10);
-    let json = serde_json::to_string(&msg).unwrap();
-    assert_eq!(json, "10");
-
-    let msg = Message::from_content("hello".into());
-    let json = serde_json::to_string(&msg).unwrap();
-    assert_eq!(json, r#""hello""#);
-}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use valitron::{
     available::{Required, StartWith},
-    custom, Message, RuleExt, Validator, Value,
+    custom, RuleExt, Validator, Value,
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -37,13 +37,14 @@ fn test_validator() {
         res.get("age").unwrap()[0],
         "age should be between 25 and 45".into()
     );
-    assert_eq!(res.get("weight").unwrap()[0], Message::from_code(100),);
+    assert_eq!(
+        res.get("weight").unwrap()[0],
+        "weight should be between 40 and 80".into(),
+    );
     assert_eq!(
         res.get("name").unwrap()[0],
         "name should be starts with `hello`".into(),
     );
-
-    //println!("{res:?}");
 }
 
 fn age_limit(n: &mut u8) -> Result<(), String> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -46,21 +46,21 @@ fn test_validator() {
     //println!("{res:?}");
 }
 
-fn age_limit(n: &mut u8) -> Result<(), &'static str> {
+fn age_limit(n: &mut u8) -> Result<(), String> {
     if *n >= 25 && *n <= 45 {
         return Ok(());
     }
-    Err("age should be between 25 and 45")
+    Err("age should be between 25 and 45".into())
 }
 
-fn weight_limit(v: &mut Value) -> Result<(), u8> {
+fn weight_limit(v: &mut Value) -> Result<(), String> {
     if let Value::Float32(n) = v {
         let n = n.get();
         if n >= 40.0 && n <= 80.0 {
             return Ok(());
         }
     }
-    Err(100)
+    Err("weight should be between 40 and 80".into())
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -35,15 +35,15 @@ fn test_validator() {
     assert!(res.len() == 3);
     assert_eq!(
         res.get("age").unwrap()[0],
-        "age should be between 25 and 45".into()
+        "age should be between 25 and 45".to_string()
     );
     assert_eq!(
         res.get("weight").unwrap()[0],
-        "weight should be between 40 and 80".into(),
+        "weight should be between 40 and 80".to_string(),
     );
     assert_eq!(
         res.get("name").unwrap()[0],
-        "name should be starts with `hello`".into(),
+        "name should be starts with `hello`".to_string(),
     );
 }
 
@@ -51,7 +51,7 @@ fn age_limit(n: &mut u8) -> Result<(), String> {
     if *n >= 25 && *n <= 45 {
         return Ok(());
     }
-    Err("age should be between 25 and 45".into())
+    Err("age should be between 25 and 45".to_string())
 }
 
 fn weight_limit(v: &mut Value) -> Result<(), String> {
@@ -78,7 +78,7 @@ fn test_has_tuple() {
 
     assert_eq!(
         res.get(0).unwrap()[0],
-        "first item should be start with `hello`".into()
+        "first item should be start with `hello`".to_string()
     );
 }
 
@@ -91,6 +91,6 @@ fn test_has_array() {
     assert!(res.len() == 1);
     assert_eq!(
         res.get([1]).unwrap()[0],
-        "this field must be start with `hello`".into()
+        "this field must be start with `hello`".to_string()
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,7 +15,7 @@ struct Person {
 
 #[test]
 fn test_validator() {
-    let validator = Validator::new()
+    let validator = Validator::<String>::new()
         .rule("name", Required.and(StartWith("hello")))
         .rule("age", custom(age_limit))
         .rule("weight", custom(weight_limit))
@@ -66,7 +66,7 @@ fn weight_limit(v: &mut Value) -> Result<(), String> {
 
 #[test]
 fn test_has_tuple() {
-    let validator = Validator::new()
+    let validator = Validator::<String>::new()
         .rule(0, StartWith("hello"))
         .message([("0.start_with", "first item should be start with `hello`")]);
 
@@ -84,7 +84,7 @@ fn test_has_tuple() {
 
 #[test]
 fn test_has_array() {
-    let validator = Validator::new().rule([1], StartWith("hello"));
+    let validator = Validator::<String>::new().rule([1], StartWith("hello"));
 
     let res = validator.validate(vec!["foo", "bar"]).unwrap_err();
 


### PR DESCRIPTION
# Intention

There are currently three types of message available:
- u8
- String
- both

`ValidatorError` is implemented `Serialize` ,when it covert to json, probability result:

- `{"field1":["message1","message2"]}`
- `{"field1":["message1",2]}`
- `{"field1":[1,2]}`

second result is type error.

# Enchance message
- support custom define
- support custom and using build-in rule, e.g.:

```rust
fn main() {
    let _validator = Validator::<MyMessage>::new()
        .rule("name", Required.and(StartWith("foo")))
        .message([
            ("name.required", MyMessage::NameRequierd),
            ("name.start_with", MyMessage::NameStartWith),
        ]);
}

#[derive(Clone)]
enum MyMessage {
    NameRequierd,
    NameStartWith,
    Undefined,
}
```

