### PR TITLE
Generics message

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,12 @@ jobs:
       - name: Run Test Lib
         run: |
           cargo test --lib
+          cargo test --example enum_msg
 
       - name: Run Test Full Features
         run: |
-            cargo test --features="full"
+          cargo test --doc --features="full"
+          cargo test --example axum --example actix --example rocket --example enum_msg_full --features="full"
 
   publish:
     needs: [test]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,7 @@ jobs:
 
       - name: Run Test Full Features
         run: |
-          cargo test --doc --features="full"
-          cargo test --example axum --example actix --example rocket --example enum_msg_full --features="full"
+          cargo test --features="full"
 
   publish:
     needs: [test]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,7 @@ name: Test and Publish
 on:
   push:
     branches: 
-      - "master"
-      - "branch*"
+      - "*"
   pull_request:
     branches:
       - "*"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "rust-analyzer.cargo.features": [
-    "full"
+    //"full"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "rust-analyzer.cargo.features": [
-    //"full"
+    "full"
   ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,13 @@ required-features = ["full"]
 name = "rocket"
 required-features = ["full"]
 
+[[example]]
+name = "enum_msg"
+
+[[example]]
+name = "enum_msg_full"
+required-features = ["full"]
+
 [dependencies]
 serde = { version = "^1.0" }
 

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -27,6 +27,7 @@ async fn index(info: web::Json<Info>) -> Result<String, ServerError> {
     info.validate(
         Validator::new()
             .rule("username", Required)
+            .map(String::from)
             .message([("username.required", "username is required")]),
     )?;
     Ok(format!("Welcome {}!", info.username))
@@ -44,7 +45,7 @@ async fn main() -> std::io::Result<()> {
 #[derive(Debug, Error)]
 pub enum ServerError {
     #[error(transparent)]
-    ValidationError(#[from] ValidatorError),
+    ValidationError(#[from] ValidatorError<String>),
     //
     // other ...
 }

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -49,6 +49,7 @@ async fn handler(Form(input): Form<BlogInput>) -> Result<Html<String>, ServerErr
     input.validate(
         Validator::new()
             .rule("title", Required.and(StartWith("hi")))
+            .map(String::from)
             .message([
                 ("title.required", "title is required"),
                 ("title.start_with", "title should be starts with `hi`"),
@@ -61,7 +62,7 @@ async fn handler(Form(input): Form<BlogInput>) -> Result<Html<String>, ServerErr
 #[derive(Debug, Error)]
 pub enum ServerError {
     #[error(transparent)]
-    ValidationError(#[from] ValidatorError),
+    ValidationError(#[from] ValidatorError<String>),
 
     #[error(transparent)]
     AxumFormRejection(#[from] FormRejection),

--- a/examples/enum_msg.rs
+++ b/examples/enum_msg.rs
@@ -8,10 +8,8 @@ fn main() {
         .message([("num.gt10", MyMessage::Gt10), ("num.lt20", MyMessage::Lt20)]);
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 enum MyMessage {
-    #[default]
-    NameRequierd,
     Gt10,
     Lt20,
 }

--- a/examples/enum_msg.rs
+++ b/examples/enum_msg.rs
@@ -1,17 +1,35 @@
 //! usage without "full" feature
 
-use valitron::{RuleExt, RuleShortcut, Validator, Value};
+use valitron::{RuleShortcut, Validator, Value};
 
 fn main() {
-    let _validator = Validator::<MyMessage>::new()
-        .rule("num", Gt10.and(Lt20))
-        .message([("num.gt10", MyMessage::Gt10), ("num.lt20", MyMessage::Lt20)]);
+    let validator = Validator::<MyMessage>::new()
+        .rule("num", Gt10)
+        .message([("num.gt10", MyMessage::Gt10)]);
+
+    let _validate = validator
+        .map(MyMessage2::from)
+        .rule("num", Lt20)
+        .message([("num.gt20", MyMessage2::Lt20)]);
 }
 
 #[derive(Clone)]
 enum MyMessage {
     Gt10,
+}
+
+#[derive(Clone)]
+enum MyMessage2 {
+    Gt10,
     Lt20,
+}
+
+impl From<MyMessage> for MyMessage2 {
+    fn from(value: MyMessage) -> Self {
+        match value {
+            MyMessage::Gt10 => MyMessage2::Gt10,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -34,12 +52,12 @@ impl RuleShortcut for Gt10 {
 struct Lt20;
 
 impl RuleShortcut for Lt20 {
-    type Message = MyMessage;
+    type Message = MyMessage2;
     fn name(&self) -> &'static str {
         "gt10"
     }
     fn message(&self) -> Self::Message {
-        MyMessage::Lt20
+        MyMessage2::Lt20
     }
     fn call(&mut self, data: &mut Value) -> bool {
         data < 20_u8

--- a/examples/enum_msg.rs
+++ b/examples/enum_msg.rs
@@ -1,0 +1,49 @@
+//! usage without "full" feature
+
+use valitron::{RuleExt, RuleShortcut, Validator, Value};
+
+fn main() {
+    let _validator = Validator::<MyMessage>::new()
+        .rule("num", Gt10.and(Lt20))
+        .message([("num.gt10", MyMessage::Gt10), ("num.lt20", MyMessage::Lt20)]);
+}
+
+#[derive(Clone, Default)]
+enum MyMessage {
+    #[default]
+    NameRequierd,
+    Gt10,
+    Lt20,
+}
+
+#[derive(Clone)]
+struct Gt10;
+
+impl RuleShortcut for Gt10 {
+    type Message = MyMessage;
+    fn name(&self) -> &'static str {
+        "gt10"
+    }
+    fn message(&self) -> Self::Message {
+        MyMessage::Gt10
+    }
+    fn call(&mut self, data: &mut Value) -> bool {
+        data > 10_u8
+    }
+}
+
+#[derive(Clone)]
+struct Lt20;
+
+impl RuleShortcut for Lt20 {
+    type Message = MyMessage;
+    fn name(&self) -> &'static str {
+        "gt10"
+    }
+    fn message(&self) -> Self::Message {
+        MyMessage::Lt20
+    }
+    fn call(&mut self, data: &mut Value) -> bool {
+        data < 20_u8
+    }
+}

--- a/examples/enum_msg_full.rs
+++ b/examples/enum_msg_full.rs
@@ -4,31 +4,28 @@ use valitron::{
 };
 
 fn main() {
-    let _validator = Validator::<MyMessage>::new()
-        .rule("name", Required.and(StartWith("foo")).and(Gt10))
+    let _validator = Validator::new()
+        .rule("name", Required.and(StartWith("foo")))
+        .map(MyMessage::from)
+        .rule("num", Gt10)
         .message([
             ("name.required", MyMessage::NameRequierd),
             ("name.start_with", MyMessage::NameStartWith),
+            ("num.gt10", MyMessage::Gt10),
         ]);
 }
-
-const GT_10_MESSAGE: &str = "gt10";
 
 #[derive(Clone)]
 enum MyMessage {
     NameRequierd,
     NameStartWith,
     Gt10,
-    Undefined,
+    NotReset,
 }
 
 impl From<Message> for MyMessage {
-    fn from(value: Message) -> Self {
-        if value.to_string() == GT_10_MESSAGE {
-            Self::Gt10
-        } else {
-            Self::Undefined
-        }
+    fn from(_value: Message) -> Self {
+        Self::NotReset
     }
 }
 
@@ -36,14 +33,14 @@ impl From<Message> for MyMessage {
 struct Gt10;
 
 impl RuleShortcut for Gt10 {
-    type Message = Message;
+    type Message = MyMessage;
 
     fn name(&self) -> &'static str {
         "gt10"
     }
 
     fn message(&self) -> Self::Message {
-        Message::undefined(GT_10_MESSAGE.into())
+        MyMessage::Gt10
     }
 
     fn call(&mut self, data: &mut Value) -> bool {

--- a/examples/enum_msg_full.rs
+++ b/examples/enum_msg_full.rs
@@ -24,7 +24,7 @@ enum MyMessage {
 
 impl From<Message> for MyMessage {
     fn from(value: Message) -> Self {
-        if value.as_str() == GT_10_MESSAGE {
+        if value.to_string() == GT_10_MESSAGE {
             Self::Gt10
         } else {
             Self::Undefined
@@ -43,10 +43,7 @@ impl RuleShortcut for Gt10 {
     }
 
     fn message(&self) -> Self::Message {
-        Message::new(
-            valitron::available::MessageKind::Undefined,
-            GT_10_MESSAGE.into(),
-        )
+        Message::undefined(GT_10_MESSAGE.into())
     }
 
     fn call(&mut self, data: &mut Value) -> bool {

--- a/examples/enum_msg_full.rs
+++ b/examples/enum_msg_full.rs
@@ -1,26 +1,55 @@
 use valitron::{
     available::{Message, Required, StartWith},
-    RuleExt, Validator,
+    RuleExt, RuleShortcut, Validator, Value,
 };
 
 fn main() {
     let _validator = Validator::<MyMessage>::new()
-        .rule("name", Required.and(StartWith("foo")))
+        .rule("name", Required.and(StartWith("foo")).and(Gt10))
         .message([
             ("name.required", MyMessage::NameRequierd),
             ("name.start_with", MyMessage::NameStartWith),
         ]);
 }
 
+const GT_10_MESSAGE: &str = "gt10";
+
 #[derive(Clone)]
 enum MyMessage {
     NameRequierd,
     NameStartWith,
+    Gt10,
     Undefined,
 }
 
 impl From<Message> for MyMessage {
-    fn from(_value: Message) -> Self {
-        Self::Undefined
+    fn from(value: Message) -> Self {
+        if value.as_str() == GT_10_MESSAGE {
+            Self::Gt10
+        } else {
+            Self::Undefined
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Gt10;
+
+impl RuleShortcut for Gt10 {
+    type Message = Message;
+
+    fn name(&self) -> &'static str {
+        "gt10"
+    }
+
+    fn message(&self) -> Self::Message {
+        Message::new(
+            valitron::available::MessageKind::Undefined,
+            GT_10_MESSAGE.into(),
+        )
+    }
+
+    fn call(&mut self, data: &mut Value) -> bool {
+        data > 10_u8
     }
 }

--- a/examples/enum_msg_full.rs
+++ b/examples/enum_msg_full.rs
@@ -1,0 +1,26 @@
+use valitron::{
+    available::{Message, Required, StartWith},
+    RuleExt, Validator,
+};
+
+fn main() {
+    let _validator = Validator::<MyMessage>::new()
+        .rule("name", Required.and(StartWith("foo")))
+        .message([
+            ("name.required", MyMessage::NameRequierd),
+            ("name.start_with", MyMessage::NameStartWith),
+        ]);
+}
+
+#[derive(Clone)]
+enum MyMessage {
+    NameRequierd,
+    NameStartWith,
+    Undefined,
+}
+
+impl From<Message> for MyMessage {
+    fn from(_value: Message) -> Self {
+        Self::Undefined
+    }
+}

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -20,7 +20,11 @@ extern crate rocket;
 
 #[get("/?<name>&<second>")]
 fn index(name: String, second: String) -> String {
-    match (name, second).validate_mut(Validator::<String>::new().rule("0", Trim.and(Required))) {
+    match (name, second).validate_mut(
+        Validator::new()
+            .rule("0", Trim.and(Required))
+            .map(String::from),
+    ) {
         Ok((name, _)) => format!("Hello, {name}!"),
         Err(_) => format!("name is required"),
     }

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -20,7 +20,7 @@ extern crate rocket;
 
 #[get("/?<name>&<second>")]
 fn index(name: String, second: String) -> String {
-    match (name, second).validate_mut(Validator::new().rule("0", Trim.and(Required))) {
+    match (name, second).validate_mut(Validator::<String>::new().rule("0", Trim.and(Required))) {
         Ok((name, _)) => format!("Hello, {name}!"),
         Err(_) => format!("name is required"),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,11 +34,11 @@
 //! assert!(res.len() == 2);
 //! # }
 //!
-//! fn age_range(age: &mut u8) -> Result<(), &'static str> {
+//! fn age_range(age: &mut u8) -> Result<(), String> {
 //!     if *age >= 25 && *age <= 45 {
 //!         Ok(())
 //!     } else {
-//!         Err("age should be between 25 and 45")
+//!         Err("age should be between 25 and 45".into())
 //!     }
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! ```rust
 //! # use serde::{Deserialize, Serialize};
 //! # use valitron::{
-//! # available::{Required, StartWith},
+//! # available::{Message, Required, StartWith},
 //! # custom, RuleExt, Validator
 //! # };
 //! #[derive(Serialize, Debug)]
@@ -16,7 +16,7 @@
 //! }
 //!
 //! # fn main() {
-//! let validator = Validator::<String>::new()
+//! let validator = Validator::new()
 //!     .rule("introduce", Required.and(StartWith("I am")))
 //!     .rule("age", custom(age_range))
 //!     .message([
@@ -34,7 +34,7 @@
 //! assert!(res.len() == 2);
 //! # }
 //!
-//! fn age_range(age: &mut u8) -> Result<(), String> {
+//! fn age_range(age: &mut u8) -> Result<(), Message> {
 //!     if *age >= 25 && *age <= 45 {
 //!         Ok(())
 //!     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! }
 //!
 //! # fn main() {
-//! let validator = Validator::new()
+//! let validator = Validator::<String>::new()
 //!     .rule("introduce", Required.and(StartWith("I am")))
 //!     .rule("age", custom(age_range))
 //!     .message([

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! # use serde::{Deserialize, Serialize};
 //! # use valitron::{
 //! # available::{Required, StartWith},
-//! # custom, Message, RuleExt, Validator
+//! # custom, RuleExt, Validator
 //! # };
 //! #[derive(Serialize, Debug)]
 //! struct Person {
@@ -96,7 +96,7 @@ mod ser;
 pub mod value;
 
 pub use register::{Validatable, Validator};
-pub use rule::{custom, IntoRuleMessage, Message, Rule, RuleExt, RuleShortcut};
+pub use rule::{custom, Rule, RuleExt, RuleShortcut};
 pub use value::{FromValue, Value, ValueMap};
 
 #[cfg(feature = "full")]

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -412,6 +412,24 @@ where
         self
     }
 
+    pub fn map<M2>(self, f: fn(M) -> M2) -> Validator<M2>
+    where
+        M2: 'static,
+    {
+        Validator {
+            rules: self
+                .rules
+                .into_iter()
+                .map(|(field, list)| (field, list.map(f)))
+                .collect(),
+            message: self
+                .message
+                .into_iter()
+                .map(|(key, msg)| (key, f(msg)))
+                .collect(),
+        }
+    }
+
     /// run validate without modifiable
     pub fn validate<T>(self, data: T) -> Result<(), ValidatorError<M>>
     where

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -81,12 +81,12 @@ macro_rules! panic_on_err {
     };
 }
 
-impl<M> Validator<M>
-where
-    M: Default,
-{
+impl<M> Validator<M> {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            rules: HashMap::new(),
+            message: HashMap::new(),
+        }
     }
 }
 

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -211,6 +211,7 @@ where
         self
     }
 
+    #[must_use]
     pub fn map<M2>(self, f: fn(M) -> M2) -> Validator<M2>
     where
         M2: 'static,

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -178,9 +178,10 @@ where
     /// # Panic
     ///
     /// When field or rule is not existing ,this will panic
-    pub fn message<'key, const N: usize>(mut self, list: [(&'key str, M); N]) -> Self
+    pub fn message<'key, const N: usize, MSG>(mut self, list: [(&'key str, MSG); N]) -> Self
     where
         M: IntoRuleMessage,
+        MSG: Into<M>,
     {
         self.message = HashMap::from_iter(
             list.map(|(key_str, v)| {
@@ -188,7 +189,7 @@ where
 
                 panic_on_err!(self.exit_message(&msg_key));
 
-                (msg_key, v.into_message())
+                (msg_key, v.into().into_message())
             })
             .into_iter(),
         );

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -453,26 +453,6 @@ impl<M> IntoIterator for ValidatorError<M> {
     }
 }
 
-impl From<ValidatorError> for Result<(), ValidatorError> {
-    fn from(value: ValidatorError) -> Self {
-        if value.is_empty() {
-            Ok(())
-        } else {
-            Err(value)
-        }
-    }
-}
-
-// impl From<ValidatorError> for Result<(), ValidatorError> {
-//     fn from(value: ValidatorError) -> Self {
-//         if value.is_empty() {
-//             Ok(())
-//         } else {
-//             Err(value)
-//         }
-//     }
-// }
-
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MessageKey {
     fields: FieldNames,

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -1,46 +1,4 @@
 //! register validator
-//! ## This is an example:
-//!
-//! ```rust
-//! # use serde::{Deserialize, Serialize};
-//! # use valitron::{
-//! # available::{Required, StartWith},
-//! # custom, RuleExt, Validator
-//! # };
-//! #[derive(Serialize, Debug)]
-//! struct Person {
-//!     introduce: &'static str,
-//!     age: u8,
-//!     weight: f32,
-//! }
-//!
-//! # fn main() {
-//! let validator = Validator::new()
-//!     .rule("introduce", Required.and(StartWith("I am")))
-//!     .rule("age", custom(age_range))
-//!     .message([
-//!         ("introduce.required", "introduce is required"),
-//!         ("introduce.start_with", "introduce should be starts with `I am`"),
-//!     ]);
-//!
-//! let person = Person {
-//!     introduce: "hi",
-//!     age: 18,
-//!     weight: 20.0,
-//! };
-//!
-//! let res = validator.validate(person).unwrap_err();
-//! assert!(res.len() == 2);
-//! # }
-//!
-//! fn age_range(age: &mut u8) -> Result<(), String> {
-//!     if *age >= 25 && *age <= 45 {
-//!         Ok(())
-//!     } else {
-//!         Err("age should be between 25 and 45".into())
-//!     }
-//! }
-//! ```
 
 use std::{
     collections::{
@@ -68,6 +26,7 @@ mod field_name;
 mod lexer;
 
 /// register a validator
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 #[derive(Default)]
 #[cfg(feature = "full")]
 pub struct Validator<M1, M = Message> {
@@ -76,6 +35,49 @@ pub struct Validator<M1, M = Message> {
 }
 
 /// register a validator
+/// ## This is an example:
+///
+/// ```rust
+/// # use serde::{Deserialize, Serialize};
+/// # use valitron::{
+/// # available::{Required, StartWith},
+/// # custom, RuleExt, Validator
+/// # };
+/// #[derive(Serialize, Debug)]
+/// struct Person {
+///     introduce: &'static str,
+///     age: u8,
+///     weight: f32,
+/// }
+///
+/// # fn main() {
+/// let validator = Validator::new()
+///     .rule("introduce", Required.and(StartWith("I am")))
+///     .rule("age", custom(age_range))
+///     .message([
+///         ("introduce.required", "introduce is required"),
+///         ("introduce.start_with", "introduce should be starts with `I am`"),
+///     ]);
+///
+/// let person = Person {
+///     introduce: "hi",
+///     age: 18,
+///     weight: 20.0,
+/// };
+///
+/// let res = validator.validate(person).unwrap_err();
+/// assert!(res.len() == 2);
+/// # }
+///
+/// fn age_range(age: &mut u8) -> Result<(), String> {
+///     if *age >= 25 && *age <= 45 {
+///         Ok(())
+///     } else {
+///         Err("age should be between 25 and 45".into())
+///     }
+/// }
+/// ```
+#[cfg_attr(docsrs, doc(cfg(not(feature = "full"))))]
 #[derive(Default)]
 #[cfg(not(feature = "full"))]
 pub struct Validator<M = String> {

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -33,11 +33,11 @@
 //! assert!(res.len() == 2);
 //! # }
 //!
-//! fn age_range(age: &mut u8) -> Result<(), &'static str> {
+//! fn age_range(age: &mut u8) -> Result<(), String> {
 //!     if *age >= 25 && *age <= 45 {
 //!         Ok(())
 //!     } else {
-//!         Err("age should be between 25 and 45")
+//!         Err("age should be between 25 and 45".into())
 //!     }
 //! }
 //! ```

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -26,21 +26,12 @@ mod field_name;
 mod lexer;
 
 /// register a validator
-#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
-#[derive(Default)]
-#[cfg(feature = "full")]
-pub struct Validator<M1, M = Message> {
-    rules: HashMap<FieldNames, RuleList<M>>,
-    message: HashMap<MessageKey, M1>,
-}
-
-/// register a validator
 /// ## This is an example:
 ///
 /// ```rust
 /// # use serde::{Deserialize, Serialize};
 /// # use valitron::{
-/// # available::{Required, StartWith},
+/// # available::{Required, StartWith, Message},
 /// # custom, RuleExt, Validator
 /// # };
 /// #[derive(Serialize, Debug)]
@@ -69,7 +60,7 @@ pub struct Validator<M1, M = Message> {
 /// assert!(res.len() == 2);
 /// # }
 ///
-/// fn age_range(age: &mut u8) -> Result<(), String> {
+/// fn age_range(age: &mut u8) -> Result<(), Message> {
 ///     if *age >= 25 && *age <= 45 {
 ///         Ok(())
 ///     } else {
@@ -77,12 +68,33 @@ pub struct Validator<M1, M = Message> {
 ///     }
 /// }
 /// ```
-#[cfg_attr(docsrs, doc(cfg(not(feature = "full"))))]
-#[derive(Default)]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+#[cfg(feature = "full")]
+pub struct Validator<M = Message> {
+    rules: HashMap<FieldNames, RuleList<M>>,
+    message: HashMap<MessageKey, M>,
+}
+
+/// register a validator
 #[cfg(not(feature = "full"))]
 pub struct Validator<M = String> {
     rules: HashMap<FieldNames, RuleList<M>>,
     message: HashMap<MessageKey, M>,
+}
+
+impl<M> Default for Validator<M> {
+    fn default() -> Self {
+        Self {
+            rules: HashMap::new(),
+            message: HashMap::new(),
+        }
+    }
+}
+
+impl<M> Validator<M> {
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 macro_rules! panic_on_err {
@@ -94,219 +106,6 @@ macro_rules! panic_on_err {
     };
 }
 
-#[cfg(feature = "full")]
-impl<M1, M> Validator<M1, M> {
-    pub fn new() -> Self {
-        Self {
-            rules: HashMap::new(),
-            message: HashMap::new(),
-        }
-    }
-}
-
-#[cfg(not(feature = "full"))]
-impl<M> Validator<M> {
-    pub fn new() -> Self {
-        Self {
-            rules: HashMap::new(),
-            message: HashMap::new(),
-        }
-    }
-}
-
-#[cfg(feature = "full")]
-impl<M1, M> Validator<M1, M>
-where
-    M1: Clone + 'static + From<M>,
-    M: Clone + 'static,
-{
-    /// # Register rules
-    ///
-    /// **Feild support multiple formats:**
-    /// - `field1` used to matching struct field
-    /// - `0`,`1`.. used to matching tuple item or tuple struct field
-    /// - `[0]`,`[1]` used to matching array item
-    /// - `[foo]` used to matching struct variant, e.g. `enum Foo{ Color { r: u8, g: u8, b: u8 } }`
-    ///
-    /// fields support nest:
-    /// - `field1.0`
-    /// - `0.color`
-    /// - `[12].1`
-    /// - `foo.1[color]`
-    /// - more combine
-    ///
-    /// BNF indicate
-    /// ```bnf
-    /// exp                    ::= <tuple_index>
-    ///                          | <array_index>
-    ///                          | <ident>
-    ///                          | <struct_variant_index>
-    ///                          | <exp> '.' <tuple_index>
-    ///                          | <exp> '.' <ident>
-    ///                          | <exp> <array_index>
-    ///                          | <exp> <struct_variant_index>
-    /// tuple_index            ::= <u8>
-    /// array_index            ::= '[' <usize> ']'
-    /// struct_variant_index   ::= '[' <ident> ']'
-    /// ```
-    ///
-    /// **Rule also support multiple formats:**
-    /// - `RuleFoo`
-    /// - `RuleFoo.and(RuleBar)` combineable
-    /// - `custom(handler)` closure usage
-    /// - `RuleFoo.custom(handler)` type and closure
-    /// - `custom(handler).and(RuleFoo)` closure and type
-    /// - `RuleFoo.and(RuleBar).bail()` when first validate error, immediately return error with one message.
-    ///
-    /// *Available Rules*
-    /// - [`Required`]
-    /// - [`StartWith`]
-    /// - [`Confirm`]
-    /// - [`Trim`]
-    /// - [`Range`]
-    /// - customizable
-    ///
-    /// # Panic
-    ///
-    /// - Field format error will be panic
-    /// - Invalid rule name will be panic
-    ///
-    /// [`Required`]: crate::available::required
-    /// [`StartWith`]: crate::available::start_with
-    /// [`Confirm`]: crate::available::confirm
-    /// [`Trim`]: crate::available::trim
-    /// [`Range`]: crate::available::range
-    pub fn rule<F, R>(mut self, field: F, rule: R) -> Self
-    where
-        F: IntoFieldName,
-        R: IntoRuleList<M>,
-    {
-        let names = panic_on_err!(field.into_field());
-        let rules = rule.into_list();
-
-        if !rules.valid_name() {
-            panic!("invalid rule name")
-        }
-
-        self.rules.insert(names, rules);
-        self
-    }
-
-    /// Custom validate error message
-    ///
-    /// Every rule has a default message, the method should be replace it with your need.
-    ///
-    /// parameter list item format:
-    /// `(field_name.rule_name, message)`
-    ///
-    /// e.g: `("name.required", "name is required")`
-    ///
-    /// # Panic
-    ///
-    /// When field or rule is not existing ,this will panic
-    pub fn message<'key, const N: usize, MSG>(mut self, list: [(&'key str, MSG); N]) -> Self
-    where
-        MSG: Into<M1>,
-    {
-        self.message = HashMap::from_iter(
-            list.map(|(key_str, v)| {
-                let msg_key = panic_on_err!(field_name::parse_message(key_str));
-
-                panic_on_err!(self.exit_message(&msg_key));
-
-                (msg_key, v.into())
-            })
-            .into_iter(),
-        );
-        self
-    }
-
-    /// run validate without modifiable
-    pub fn validate<T>(self, data: T) -> Result<(), ValidatorError<M1>>
-    where
-        T: Serialize,
-    {
-        let value = data.serialize(Serializer).unwrap();
-
-        let mut value_map = ValueMap::new(value);
-
-        let message = self.inner_validate(&mut value_map);
-
-        if message.is_empty() {
-            Ok(())
-        } else {
-            Err(message)
-        }
-    }
-
-    /// run validate with modifiable
-    pub fn validate_mut<'de, T>(self, data: T) -> Result<T, ValidatorError<M1>>
-    where
-        T: Serialize + serde::de::Deserialize<'de>,
-    {
-        let value = data.serialize(Serializer).unwrap();
-
-        let mut value_map = ValueMap::new(value);
-
-        let message = self.inner_validate(&mut value_map);
-
-        if message.is_empty() {
-            Ok(T::deserialize(value_map.value()).unwrap())
-        } else {
-            Err(message)
-        }
-    }
-
-    fn inner_validate(self, value_map: &mut ValueMap) -> ValidatorError<M1> {
-        let mut message = ValidatorError::with_capacity(self.rules.len());
-
-        for (names, rules) in self.rules.iter() {
-            value_map.index(names.clone());
-            let rule_resp = rules.clone().call(value_map);
-
-            let mut field_msg = Vec::with_capacity(rule_resp.len());
-            for (rule, msg) in rule_resp.into_iter() {
-                let final_msg =
-                    match self.get_message(&MessageKey::new(names.clone(), rule.to_string())) {
-                        Some(s) => s.clone(),
-                        None => msg.into(),
-                    };
-                field_msg.push(final_msg);
-            }
-
-            field_msg.shrink_to_fit();
-
-            message.push(names.clone(), field_msg);
-        }
-
-        message.shrink_to_fit();
-
-        message
-    }
-
-    fn rule_get(&self, names: &FieldNames) -> Option<&RuleList<M>> {
-        self.rules.get(names)
-    }
-
-    fn exit_message(&self, MessageKey { fields, rule }: &MessageKey) -> Result<(), String> {
-        let names = self.rule_get(fields).ok_or(format!(
-            "the field \"{}\" not found in validator",
-            fields.as_str()
-        ))?;
-
-        if names.contains(rule) {
-            Ok(())
-        } else {
-            Err(format!("rule \"{rule}\" is not found in rules"))
-        }
-    }
-
-    fn get_message(&self, key: &MessageKey) -> Option<&M1> {
-        self.message.get(key)
-    }
-}
-
-#[cfg(not(feature = "full"))]
 impl<M> Validator<M>
 where
     M: Clone + 'static,
@@ -516,7 +315,6 @@ where
 }
 
 /// validateable for any types
-#[cfg(not(feature = "full"))]
 pub trait Validatable<M> {
     /// if not change value
     fn validate(&self, validator: Validator<M>) -> Result<(), ValidatorError<M>>;
@@ -527,7 +325,6 @@ pub trait Validatable<M> {
         Self: Sized + Deserialize<'de>;
 }
 
-#[cfg(not(feature = "full"))]
 impl<T, M> Validatable<M> for T
 where
     T: Serialize,
@@ -545,39 +342,9 @@ where
     }
 }
 
-#[cfg(feature = "full")]
-pub trait Validatable<M1, M> {
-    /// if not change value
-    fn validate(&self, validator: Validator<M1, M>) -> Result<(), ValidatorError<M1>>;
-
-    /// if need to change value, e.g. `trim`
-    fn validate_mut<'de>(self, validator: Validator<M1, M>) -> Result<Self, ValidatorError<M1>>
-    where
-        Self: Sized + Deserialize<'de>;
-}
-
-#[cfg(feature = "full")]
-impl<T, M, M1> Validatable<M1, M> for T
-where
-    T: Serialize,
-    M: Clone + 'static,
-    M1: Clone + 'static + From<M>,
-{
-    fn validate(&self, validator: Validator<M1, M>) -> Result<(), ValidatorError<M1>> {
-        validator.validate(self)
-    }
-
-    fn validate_mut<'de>(self, validator: Validator<M1, M>) -> Result<Self, ValidatorError<M1>>
-    where
-        Self: Sized + Deserialize<'de>,
-    {
-        validator.validate_mut(self)
-    }
-}
-
 /// store validate error message
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ValidatorError<M = String> {
+pub struct ValidatorError<M> {
     message: HashMap<FieldNames, Vec<M>>,
 }
 

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -53,7 +53,7 @@ use std::{
 };
 
 use crate::{
-    rule::{IntoRuleList, IntoRuleMessage, Message, RuleList},
+    rule::{IntoRuleList, RuleList},
     ser::Serializer,
     value::ValueMap,
 };
@@ -67,9 +67,9 @@ mod lexer;
 
 /// register a validator
 #[derive(Default)]
-pub struct Validator<M> {
+pub struct Validator<M = String> {
     rules: HashMap<FieldNames, RuleList<M>>,
-    message: HashMap<MessageKey, Message>,
+    message: HashMap<MessageKey, M>,
 }
 
 macro_rules! panic_on_err {
@@ -180,7 +180,6 @@ where
     /// When field or rule is not existing ,this will panic
     pub fn message<'key, const N: usize, MSG>(mut self, list: [(&'key str, MSG); N]) -> Self
     where
-        M: IntoRuleMessage,
         MSG: Into<M>,
     {
         self.message = HashMap::from_iter(
@@ -189,7 +188,7 @@ where
 
                 panic_on_err!(self.exit_message(&msg_key));
 
-                (msg_key, v.into().into_message())
+                (msg_key, v.into())
             })
             .into_iter(),
         );
@@ -197,7 +196,7 @@ where
     }
 
     /// run validate without modifiable
-    pub fn validate<T>(self, data: T) -> Result<(), ValidatorError>
+    pub fn validate<T>(self, data: T) -> Result<(), ValidatorError<M>>
     where
         T: Serialize,
     {
@@ -215,7 +214,7 @@ where
     }
 
     /// run validate with modifiable
-    pub fn validate_mut<'de, T>(self, data: T) -> Result<T, ValidatorError>
+    pub fn validate_mut<'de, T>(self, data: T) -> Result<T, ValidatorError<M>>
     where
         T: Serialize + serde::de::Deserialize<'de>,
     {
@@ -232,7 +231,7 @@ where
         }
     }
 
-    fn inner_validate(self, value_map: &mut ValueMap) -> ValidatorError {
+    fn inner_validate(self, value_map: &mut ValueMap) -> ValidatorError<M> {
         let mut message = ValidatorError::with_capacity(self.rules.len());
 
         for (names, rules) in self.rules.iter() {
@@ -276,7 +275,7 @@ where
         }
     }
 
-    fn get_message(&self, key: &MessageKey) -> Option<&Message> {
+    fn get_message(&self, key: &MessageKey) -> Option<&M> {
         self.message.get(key)
     }
 }
@@ -284,10 +283,10 @@ where
 /// validateable for any types
 pub trait Validatable<M> {
     /// if not change value
-    fn validate(&self, validator: Validator<M>) -> Result<(), ValidatorError>;
+    fn validate(&self, validator: Validator<M>) -> Result<(), ValidatorError<M>>;
 
     /// if need to change value, e.g. `trim`
-    fn validate_mut<'de>(self, validator: Validator<M>) -> Result<Self, ValidatorError>
+    fn validate_mut<'de>(self, validator: Validator<M>) -> Result<Self, ValidatorError<M>>
     where
         Self: Sized + Deserialize<'de>;
 }
@@ -297,11 +296,11 @@ where
     T: Serialize,
     M: Clone + 'static,
 {
-    fn validate(&self, validator: Validator<M>) -> Result<(), ValidatorError> {
+    fn validate(&self, validator: Validator<M>) -> Result<(), ValidatorError<M>> {
         validator.validate(self)
     }
 
-    fn validate_mut<'de>(self, validator: Validator<M>) -> Result<Self, ValidatorError>
+    fn validate_mut<'de>(self, validator: Validator<M>) -> Result<Self, ValidatorError<M>>
     where
         Self: Sized + Deserialize<'de>,
     {
@@ -311,11 +310,14 @@ where
 
 /// store validate error message
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ValidatorError {
-    message: HashMap<FieldNames, Vec<Message>>,
+pub struct ValidatorError<M = String> {
+    message: HashMap<FieldNames, Vec<M>>,
 }
 
-impl Serialize for ValidatorError {
+impl<M> Serialize for ValidatorError<M>
+where
+    M: serde::Serialize,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -324,13 +326,13 @@ impl Serialize for ValidatorError {
     }
 }
 
-impl Display for ValidatorError {
+impl<M> Display for ValidatorError<M> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         "validate error".fmt(f)
     }
 }
 
-impl Error for ValidatorError {}
+impl<M> Error for ValidatorError<M> where M: std::fmt::Debug {}
 
 // impl Deref for ValidatorError {
 //     type Target = HashMap<FieldNames, Vec<String>>;
@@ -339,7 +341,7 @@ impl Error for ValidatorError {}
 //     }
 // }
 
-impl ValidatorError {
+impl<M> ValidatorError<M> {
     #[cfg(test)]
     fn new() -> Self {
         Self {
@@ -352,7 +354,7 @@ impl ValidatorError {
         }
     }
 
-    fn push(&mut self, field_name: FieldNames, message: Vec<Message>) {
+    fn push(&mut self, field_name: FieldNames, message: Vec<M>) {
         if !message.is_empty() {
             self.message.insert(field_name, message);
         }
@@ -362,12 +364,12 @@ impl ValidatorError {
         self.message.shrink_to_fit()
     }
 
-    pub fn get<K: IntoFieldName>(&self, key: K) -> Option<&Vec<Message>> {
+    pub fn get<K: IntoFieldName>(&self, key: K) -> Option<&Vec<M>> {
         let k = key.into_field().ok()?;
         self.message.get(&k)
     }
 
-    pub fn get_key_value<K: IntoFieldName>(&self, key: K) -> Option<(&FieldNames, &Vec<Message>)> {
+    pub fn get_key_value<K: IntoFieldName>(&self, key: K) -> Option<(&FieldNames, &Vec<M>)> {
         let k = key.into_field().ok()?;
         self.message.get_key_value(&k)
     }
@@ -379,15 +381,15 @@ impl ValidatorError {
         }
     }
 
-    pub fn keys(&self) -> Keys<'_, FieldNames, Vec<Message>> {
+    pub fn keys(&self) -> Keys<'_, FieldNames, Vec<M>> {
         self.message.keys()
     }
 
-    pub fn iter(&self) -> Iter<'_, FieldNames, Vec<Message>> {
+    pub fn iter(&self) -> Iter<'_, FieldNames, Vec<M>> {
         self.message.iter()
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<'_, FieldNames, Vec<Message>> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, FieldNames, Vec<M>> {
         self.message.iter_mut()
     }
 
@@ -400,17 +402,17 @@ impl ValidatorError {
     }
 }
 
-impl<'a> IntoIterator for &'a mut ValidatorError {
-    type Item = (&'a FieldNames, &'a mut Vec<Message>);
-    type IntoIter = IterMut<'a, FieldNames, Vec<Message>>;
+impl<'a, M> IntoIterator for &'a mut ValidatorError<M> {
+    type Item = (&'a FieldNames, &'a mut Vec<M>);
+    type IntoIter = IterMut<'a, FieldNames, Vec<M>>;
     fn into_iter(self) -> Self::IntoIter {
         self.message.iter_mut()
     }
 }
 
-impl IntoIterator for ValidatorError {
-    type Item = (FieldNames, Vec<Message>);
-    type IntoIter = IntoIter<FieldNames, Vec<Message>>;
+impl<M> IntoIterator for ValidatorError<M> {
+    type Item = (FieldNames, Vec<M>);
+    type IntoIter = IntoIter<FieldNames, Vec<M>>;
     fn into_iter(self) -> Self::IntoIter {
         self.message.into_iter()
     }
@@ -425,6 +427,16 @@ impl From<ValidatorError> for Result<(), ValidatorError> {
         }
     }
 }
+
+// impl From<ValidatorError> for Result<(), ValidatorError> {
+//     fn from(value: ValidatorError) -> Self {
+//         if value.is_empty() {
+//             Ok(())
+//         } else {
+//             Err(value)
+//         }
+//     }
+// }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MessageKey {
@@ -455,7 +467,7 @@ impl MessageKey {
 
 #[test]
 fn test_validator_error_serialize() {
-    let mut error = ValidatorError::new();
+    let mut error = ValidatorError::<String>::new();
     error.push(
         FieldNames::new("field1".into()),
         vec!["message1".into(), "message2".into()],

--- a/src/rule/available/confirm.rs
+++ b/src/rule/available/confirm.rs
@@ -4,6 +4,8 @@ use std::fmt::Display;
 
 use crate::{register::FieldNames, value::ValueMap, RuleShortcut, Value};
 
+use super::{Message, MessageKind};
+
 #[derive(Clone)]
 pub struct Confirm<T>(pub T);
 
@@ -30,13 +32,16 @@ impl<T> Confirm<T>
 where
     T: Display,
 {
-    fn message_in(&self) -> String {
-        format!("this field value must be equal to `{}` field", self.0)
+    fn message_in(&self) -> Message {
+        Message::new(
+            MessageKind::Confirm,
+            format!("this field value must be equal to `{}` field", self.0),
+        )
     }
 }
 
 impl RuleShortcut for Confirm<String> {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         self.name_in()
@@ -58,7 +63,7 @@ impl RuleShortcut for Confirm<String> {
 }
 
 impl RuleShortcut for Confirm<&str> {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         self.name_in()

--- a/src/rule/available/confirm.rs
+++ b/src/rule/available/confirm.rs
@@ -17,7 +17,7 @@ impl<T> Confirm<T> {
 
 impl<T> Confirm<T>
 where
-    T: ToString,
+    T: Display,
 {
     fn get_target_value<'v>(&self, value: &'v ValueMap) -> Option<&'v Value> {
         let target = value.get(&FieldNames::new(self.0.to_string()));
@@ -26,17 +26,9 @@ where
             _ => None,
         }
     }
-}
 
-impl<T> Confirm<T>
-where
-    T: Display,
-{
     fn message_in(&self) -> Message {
-        Message::new(
-            MessageKind::Confirm,
-            format!("this field value must be equal to `{}` field", self.0),
-        )
+        Message::new(MessageKind::Confirm(self.0.to_string()))
     }
 }
 

--- a/src/rule/available/mod.rs
+++ b/src/rule/available/mod.rs
@@ -16,7 +16,7 @@ pub use start_with::StartWith;
 pub use trim::Trim;
 
 /// Error message returned when validate fail
-#[derive(Debug, Clone, Eq, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct Message {
     kind: MessageKind,
 }
@@ -29,12 +29,6 @@ pub enum MessageKind {
     Trim,
     Range,
     Undefined(String),
-}
-
-impl Default for MessageKind {
-    fn default() -> Self {
-        Self::Undefined(String::new())
-    }
 }
 
 impl Message {

--- a/src/rule/available/mod.rs
+++ b/src/rule/available/mod.rs
@@ -9,5 +9,103 @@ pub mod trim;
 pub use confirm::Confirm;
 pub use range::Range;
 pub use required::Required;
+use serde::{ser::SerializeMap, Serialize};
 pub use start_with::StartWith;
 pub use trim::Trim;
+
+/// Error message returned when validate fail
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct Message {
+    kind: MessageKind,
+    content: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub enum MessageKind {
+    Required,
+    Confirm,
+    StartWith,
+    Trim,
+    Range,
+
+    #[default]
+    Undefined,
+}
+
+impl Message {
+    pub fn new(kind: MessageKind, content: String) -> Self {
+        Message { kind, content }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.content
+    }
+
+    pub fn kind(&self) -> &MessageKind {
+        &self.kind
+    }
+}
+
+impl From<Message> for String {
+    fn from(msg: Message) -> Self {
+        msg.content
+    }
+}
+impl From<String> for Message {
+    fn from(content: String) -> Self {
+        Self {
+            kind: MessageKind::Undefined,
+            content,
+        }
+    }
+}
+
+impl Serialize for Message {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // if self.kind != 0 && !self.content.is_empty() {
+        //     let mut map = serializer.serialize_map(Some(2))?;
+        //     map.serialize_entry("code", &self.code)?;
+        //     map.serialize_entry("content", &self.content)?;
+        //     map.end()
+        // } else if self.code != 0 {
+        //     serializer.serialize_u8(self.code)
+        // } else {
+
+        // }
+        serializer.serialize_str(&self.content)
+    }
+}
+
+impl PartialEq<Message> for String {
+    fn eq(&self, other: &Message) -> bool {
+        self == &other.content
+    }
+}
+
+pub trait FromRuleMessage {
+    fn from_message(msg: Message) -> Self;
+}
+
+impl FromRuleMessage for Message {
+    fn from_message(msg: Message) -> Self {
+        msg
+    }
+}
+
+// #[test]
+// fn test_message_serialize() {
+//     let msg = Message::new(10, "hello world".into());
+//     let json = serde_json::to_string(&msg).unwrap();
+//     assert_eq!(json, r#"{"code":10,"content":"hello world"}"#);
+
+//     let msg = Message::from_code(10);
+//     let json = serde_json::to_string(&msg).unwrap();
+//     assert_eq!(json, "10");
+
+//     let msg = Message::from_content("hello".into());
+//     let json = serde_json::to_string(&msg).unwrap();
+//     assert_eq!(json, r#""hello""#);
+// }

--- a/src/rule/available/mod.rs
+++ b/src/rule/available/mod.rs
@@ -60,6 +60,12 @@ impl From<String> for Message {
     }
 }
 
+impl From<&str> for Message {
+    fn from(content: &str) -> Self {
+        content.to_string().into()
+    }
+}
+
 impl Display for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.kind.fmt(f)

--- a/src/rule/available/mod.rs
+++ b/src/rule/available/mod.rs
@@ -1,24 +1,34 @@
 //! available rules collection
 
+use std::fmt::Display;
+
+use serde::Serialize;
+
 pub mod confirm;
 pub mod range;
 pub mod required;
 pub mod start_with;
 pub mod trim;
 
-use std::fmt::Display;
-
 pub use confirm::Confirm;
 pub use range::Range;
 pub use required::Required;
-use serde::Serialize;
 pub use start_with::StartWith;
 pub use trim::Trim;
 
 /// Error message returned when validate fail
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Message {
     kind: MessageKind,
+}
+
+impl Serialize for Message {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.kind.serialize(serializer)
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
@@ -103,17 +113,13 @@ impl FromRuleMessage for Message {
     }
 }
 
-// #[test]
-// fn test_message_serialize() {
-//     let msg = Message::new(10, "hello world".into());
-//     let json = serde_json::to_string(&msg).unwrap();
-//     assert_eq!(json, r#"{"code":10,"content":"hello world"}"#);
+#[test]
+fn test_message_serialize() {
+    let msg = Message::new(MessageKind::Required);
+    let json = serde_json::to_string(&msg).unwrap();
+    assert_eq!(json, r#""Required""#);
 
-//     let msg = Message::from_code(10);
-//     let json = serde_json::to_string(&msg).unwrap();
-//     assert_eq!(json, "10");
-
-//     let msg = Message::from_content("hello".into());
-//     let json = serde_json::to_string(&msg).unwrap();
-//     assert_eq!(json, r#""hello""#);
-// }
+    let msg = Message::new(MessageKind::Confirm("foo".into()));
+    let json = serde_json::to_string(&msg).unwrap();
+    assert_eq!(json, r#"{"Confirm":"foo"}"#);
+}

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -4,7 +4,7 @@
 //! ```
 //! # use valitron::{Validator, available::Range};
 //! # fn main() {
-//! let validator = Validator::<String>::new()
+//! let validator = Validator::new()
 //!     .rule("num", Range::new(10..20));
 //! # }
 //! ```

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -4,7 +4,7 @@
 //! ```
 //! # use valitron::{Validator, available::Range};
 //! # fn main() {
-//! let validator = Validator::new()
+//! let validator = Validator::<String>::new()
 //!     .rule("num", Range::new(10..20));
 //! # }
 //! ```

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -112,10 +112,10 @@ mod tests {
 
     use super::{super::Required, Range};
 
-    fn register<R: IntoRuleList>(_: R) {}
+    fn register<R: IntoRuleList<M>, M>(_: R) {}
 
     #[test]
     fn test_register() {
-        register(Required.and(Range::new(1..10)));
+        //register::<_, String>(Required.and(Range::new(1..10)));
     }
 }

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -11,6 +11,7 @@
 
 use std::{marker::PhantomData, ops::RangeBounds};
 
+use super::Message;
 use crate::{RuleShortcut, Value};
 
 #[derive(Clone)]
@@ -30,8 +31,11 @@ impl<T, Num> Range<T, Num> {
     fn name_in(&self) -> &'static str {
         "range"
     }
-    fn message_in(&self) -> String {
-        "the value not in the range".into()
+    fn message_in(&self) -> Message {
+        Message::new(
+            super::MessageKind::Range,
+            "the value not in the range".into(),
+        )
     }
 }
 
@@ -41,7 +45,7 @@ macro_rules! impl_range {
         where
             T: RangeBounds<$ty> + Clone + 'static,
         {
-            type Message = String;
+            type Message = Message;
             fn name(&self) -> &'static str {
                 self.name_in()
             }
@@ -72,7 +76,7 @@ impl<T> RuleShortcut for Range<T, f32>
 where
     T: RangeBounds<f32> + Clone + 'static,
 {
-    type Message = String;
+    type Message = Message;
     fn name(&self) -> &'static str {
         self.name_in()
     }
@@ -91,7 +95,7 @@ impl<T> RuleShortcut for Range<T, f64>
 where
     T: RangeBounds<f64> + Clone + 'static,
 {
-    type Message = String;
+    type Message = Message;
     fn name(&self) -> &'static str {
         self.name_in()
     }

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -30,8 +30,8 @@ impl<T, Num> Range<T, Num> {
     fn name_in(&self) -> &'static str {
         "range"
     }
-    fn message_in(&self) -> &'static str {
-        "the value not in the range"
+    fn message_in(&self) -> String {
+        "the value not in the range".into()
     }
 }
 
@@ -41,7 +41,7 @@ macro_rules! impl_range {
         where
             T: RangeBounds<$ty> + Clone + 'static,
         {
-            type Message = &'static str;
+            type Message = String;
             fn name(&self) -> &'static str {
                 self.name_in()
             }
@@ -72,7 +72,7 @@ impl<T> RuleShortcut for Range<T, f32>
 where
     T: RangeBounds<f32> + Clone + 'static,
 {
-    type Message = &'static str;
+    type Message = String;
     fn name(&self) -> &'static str {
         self.name_in()
     }
@@ -91,7 +91,7 @@ impl<T> RuleShortcut for Range<T, f64>
 where
     T: RangeBounds<f64> + Clone + 'static,
 {
-    type Message = &'static str;
+    type Message = String;
     fn name(&self) -> &'static str {
         self.name_in()
     }

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -118,6 +118,6 @@ mod tests {
 
     #[test]
     fn test_register() {
-        //register::<_, String>(Required.and(Range::new(1..10)));
+        register(Required.and(Range::new(1..10)));
     }
 }

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -31,11 +31,9 @@ impl<T, Num> Range<T, Num> {
     fn name_in(&self) -> &'static str {
         "range"
     }
+
     fn message_in(&self) -> Message {
-        Message::new(
-            super::MessageKind::Range,
-            "the value not in the range".into(),
-        )
+        Message::new(super::MessageKind::Range)
     }
 }
 

--- a/src/rule/available/required.rs
+++ b/src/rule/available/required.rs
@@ -12,11 +12,9 @@ impl RuleShortcut for Required {
     fn name(&self) -> &'static str {
         "required"
     }
+
     fn message(&self) -> Self::Message {
-        Message::new(
-            super::MessageKind::Required,
-            "this field is required".into(),
-        )
+        Message::new(super::MessageKind::Required)
     }
 
     fn call(&mut self, value: &mut Value) -> bool {

--- a/src/rule/available/required.rs
+++ b/src/rule/available/required.rs
@@ -1,18 +1,22 @@
 //! Value can not be empty
 
+use super::Message;
 use crate::{RuleShortcut, Value};
 
 #[derive(Clone, Debug)]
 pub struct Required;
 
 impl RuleShortcut for Required {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         "required"
     }
     fn message(&self) -> Self::Message {
-        "this field is required".into()
+        Message::new(
+            super::MessageKind::Required,
+            "this field is required".into(),
+        )
     }
 
     fn call(&mut self, value: &mut Value) -> bool {

--- a/src/rule/available/required.rs
+++ b/src/rule/available/required.rs
@@ -6,13 +6,13 @@ use crate::{RuleShortcut, Value};
 pub struct Required;
 
 impl RuleShortcut for Required {
-    type Message = &'static str;
+    type Message = String;
 
     fn name(&self) -> &'static str {
         "required"
     }
     fn message(&self) -> Self::Message {
-        "this field is required"
+        "this field is required".into()
     }
 
     fn call(&mut self, value: &mut Value) -> bool {

--- a/src/rule/available/start_with.rs
+++ b/src/rule/available/start_with.rs
@@ -20,10 +20,7 @@ where
     T: Display,
 {
     fn message_in(&self) -> Message {
-        Message::new(
-            super::MessageKind::StartWith,
-            format!("this field must be start with `{}`", self.0),
-        )
+        Message::new(super::MessageKind::StartWith(self.0.to_string()))
     }
 }
 
@@ -33,9 +30,11 @@ impl RuleShortcut for StartWith<&str> {
     fn name(&self) -> &'static str {
         self.name_in()
     }
+
     fn message(&self) -> Self::Message {
         self.message_in()
     }
+
     fn call(&mut self, value: &mut Value) -> bool {
         match value {
             Value::String(s) => s.starts_with(self.0),
@@ -50,9 +49,11 @@ impl RuleShortcut for StartWith<char> {
     fn name(&self) -> &'static str {
         self.name_in()
     }
+
     fn message(&self) -> Self::Message {
         self.message_in()
     }
+
     fn call(&mut self, value: &mut Value) -> bool {
         match value {
             Value::String(s) => s.starts_with(self.0),

--- a/src/rule/available/start_with.rs
+++ b/src/rule/available/start_with.rs
@@ -4,6 +4,8 @@ use std::fmt::Display;
 
 use crate::{RuleShortcut, Value};
 
+use super::Message;
+
 #[derive(Clone, Debug)]
 pub struct StartWith<T>(pub T);
 
@@ -17,13 +19,16 @@ impl<T> StartWith<T>
 where
     T: Display,
 {
-    fn message_in(&self) -> String {
-        format!("this field must be start with `{}`", self.0)
+    fn message_in(&self) -> Message {
+        Message::new(
+            super::MessageKind::StartWith,
+            format!("this field must be start with `{}`", self.0),
+        )
     }
 }
 
 impl RuleShortcut for StartWith<&str> {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         self.name_in()
@@ -40,7 +45,7 @@ impl RuleShortcut for StartWith<&str> {
 }
 
 impl RuleShortcut for StartWith<char> {
-    type Message = String;
+    type Message = Message;
 
     fn name(&self) -> &'static str {
         self.name_in()

--- a/src/rule/available/trim.rs
+++ b/src/rule/available/trim.rs
@@ -1,12 +1,12 @@
 //! Modifies a string by leading and trailing whitespace removed
 
-use crate::{Message, RuleShortcut, Value};
+use crate::{RuleShortcut, Value};
 
 #[derive(Clone)]
 pub struct Trim;
 
 impl RuleShortcut for Trim {
-    type Message = Message;
+    type Message = String;
 
     fn call(&mut self, data: &mut crate::Value) -> bool {
         match data {
@@ -18,7 +18,7 @@ impl RuleShortcut for Trim {
     }
 
     fn message(&self) -> Self::Message {
-        Message::default()
+        String::default()
     }
 
     fn name(&self) -> &'static str {

--- a/src/rule/available/trim.rs
+++ b/src/rule/available/trim.rs
@@ -2,11 +2,13 @@
 
 use crate::{RuleShortcut, Value};
 
+use super::Message;
+
 #[derive(Clone)]
 pub struct Trim;
 
 impl RuleShortcut for Trim {
-    type Message = String;
+    type Message = Message;
 
     fn call(&mut self, data: &mut crate::Value) -> bool {
         match data {
@@ -18,7 +20,7 @@ impl RuleShortcut for Trim {
     }
 
     fn message(&self) -> Self::Message {
-        String::default()
+        Message::default()
     }
 
     fn name(&self) -> &'static str {

--- a/src/rule/available/trim.rs
+++ b/src/rule/available/trim.rs
@@ -20,7 +20,7 @@ impl RuleShortcut for Trim {
     }
 
     fn message(&self) -> Self::Message {
-        Message::new(super::MessageKind::Trim, String::new())
+        Message::new(super::MessageKind::Trim)
     }
 
     fn name(&self) -> &'static str {

--- a/src/rule/available/trim.rs
+++ b/src/rule/available/trim.rs
@@ -20,7 +20,7 @@ impl RuleShortcut for Trim {
     }
 
     fn message(&self) -> Self::Message {
-        Message::default()
+        Message::new(super::MessageKind::Trim, String::new())
     }
 
     fn name(&self) -> &'static str {

--- a/src/rule/boxed.rs
+++ b/src/rule/boxed.rs
@@ -4,15 +4,16 @@ use crate::value::ValueMap;
 
 use super::{IntoRuleMessage, Message, Rule};
 
-pub struct ErasedRule(pub(super) Box<dyn BoxedRule>);
+pub struct ErasedRule<M>(pub(super) Box<dyn BoxedRule>, PhantomData<M>);
 
-impl ErasedRule {
-    pub fn new<H, M>(handler: H) -> Self
+impl<M> ErasedRule<M> {
+    pub fn new<H, S>(handler: H) -> Self
     where
-        H: Rule<M>,
-        M: 'static,
+        H: Rule<S, Message = M>,
+        S: 'static,
+        M: IntoRuleMessage + 'static,
     {
-        Self(Box::new(handler.into_boxed()))
+        Self(Box::new(handler.into_boxed()), PhantomData)
     }
 
     pub fn name(&self) -> &'static str {
@@ -23,9 +24,9 @@ impl ErasedRule {
     }
 }
 
-impl Clone for ErasedRule {
+impl<M> Clone for ErasedRule<M> {
     fn clone(&self) -> Self {
-        Self(self.0.clone_box())
+        Self(self.0.clone_box(), PhantomData)
     }
 }
 

--- a/src/rule/boxed.rs
+++ b/src/rule/boxed.rs
@@ -48,16 +48,16 @@ pub trait BoxedRule<M> {
 
 pub struct RuleIntoBoxed<H, M, T> {
     handler: H,
-    other: PhantomData<fn() -> T>,
-    msg: PhantomData<fn() -> M>,
+    _marker: PhantomData<fn() -> T>,
+    _message: PhantomData<fn() -> M>,
 }
 
 impl<H, M, T> RuleIntoBoxed<H, M, T> {
     pub(super) fn new(handler: H) -> Self {
         Self {
             handler,
-            other: PhantomData,
-            msg: PhantomData,
+            _marker: PhantomData,
+            _message: PhantomData,
         }
     }
 }
@@ -69,8 +69,8 @@ where
     fn clone(&self) -> Self {
         Self {
             handler: self.handler.clone(),
-            other: PhantomData,
-            msg: PhantomData,
+            _marker: PhantomData,
+            _message: PhantomData,
         }
     }
 }

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -105,7 +105,7 @@ pub trait RuleExt<M> {
 impl<R, M> RuleExt<M> for R
 where
     R: Rule<(), Message = M> + Clone,
-    M: Default + 'static,
+    M: 'static,
 {
     fn and<R2>(self, other: R2) -> RuleList<M>
     where
@@ -132,11 +132,19 @@ where
 }
 
 /// Rules collection
-/// TODO remove Default
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct RuleList<M> {
     list: Vec<ErasedRule<M>>,
     is_bail: bool,
+}
+
+impl<M> Default for RuleList<M> {
+    fn default() -> Self {
+        Self {
+            list: Vec::new(),
+            is_bail: false,
+        }
+    }
 }
 
 impl<M> RuleList<M>
@@ -237,7 +245,7 @@ where
     F: for<'a> FnOnce(&'a mut V) -> Result<(), M1> + 'static + Clone,
     F: Rule<(V, M), Message = M>,
     V: FromValue + 'static,
-    M: Default + 'static + From<M1>,
+    M: 'static + From<M1>,
 {
     RuleList {
         list: vec![ErasedRule::new(f)],
@@ -253,7 +261,7 @@ impl<M> IntoRuleList<M> for RuleList<M> {
 impl<R, M> IntoRuleList<M> for R
 where
     R: Rule<(), Message = M> + Clone,
-    M: Default + 'static,
+    M: 'static,
 {
     fn into_list(self) -> RuleList<M> {
         RuleList {

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -388,42 +388,59 @@ where
     }
 }
 
-// #[cfg(all(test, feature = "full"))]
-// mod test_regster {
-//     use super::available::*;
-//     use super::*;
-//     fn register<R: IntoRuleList<M>, M>(_: R) {}
+#[cfg(all(test, feature = "full"))]
+mod test_regster {
+    use super::available::*;
+    use super::*;
+    fn register<R: IntoRuleList<M>, M>(_: R) {}
 
-//     fn hander(_val: &mut ValueMap) -> Result<(), String> {
-//         Ok(())
-//     }
-//     fn hander2(_val: &mut Value) -> Result<(), String> {
-//         Ok(())
-//     }
+    fn hander(_val: &mut ValueMap) -> Result<(), String> {
+        Ok(())
+    }
+    fn hander2(_val: &mut Value) -> Result<(), String> {
+        Ok(())
+    }
 
-//     #[test]
-//     fn test() {
-//         register(Required);
-//         register(Required.custom(hander2));
-//         register(Required.custom(hander));
-//         register(Required.and(StartWith("foo")));
-//         register(Required.and(StartWith("foo")).bail());
-//         register(Required.and(StartWith("foo")).custom(hander2).bail());
-//         register(
-//             Required
-//                 .and(StartWith("foo"))
-//                 .custom(hander2)
-//                 .custom(hander)
-//                 .bail(),
-//         );
-//         register(custom(hander2));
-//         register(custom(hander));
-//         register(custom(hander).and(StartWith("foo")));
-//         register(custom(hander).and(StartWith("foo")).bail());
-//         register(custom(|_a: &mut u8| Ok::<_, u8>(())));
-//         register(custom(|_a: &mut u8| Ok::<_, u8>(())));
-//     }
-// }
+    #[derive(Clone)]
+    struct Gt10;
+
+    impl RuleShortcut for Gt10 {
+        type Message = u8;
+        fn name(&self) -> &'static str {
+            "gt10"
+        }
+        fn message(&self) -> Self::Message {
+            1
+        }
+        fn call(&mut self, data: &mut Value) -> bool {
+            data > 10_u8
+        }
+    }
+
+    #[test]
+    fn test() {
+        register(Required);
+        register(Required.custom(hander2));
+        register(Required.custom(hander));
+        register(Required.and(StartWith("foo")));
+        register(Required.and(StartWith("foo")).bail());
+        register(Required.and(StartWith("foo")).custom(hander2).bail());
+        register(
+            Required
+                .and(StartWith("foo"))
+                .custom(hander2)
+                .custom(hander)
+                .bail(),
+        );
+        register(custom(hander2));
+        register(custom(hander));
+        register(custom(hander).and(StartWith("foo")));
+        register(custom(hander).and(StartWith("foo")).bail());
+        register(custom(|_a: &mut u8| Ok::<_, u8>(())).and(Gt10));
+        register(Gt10.custom(|_a: &mut u8| Ok::<_, u8>(())));
+        register(custom(|_a: &mut u8| Ok::<_, u8>(())));
+    }
+}
 
 /// used by convenient implementation custom rules.
 pub trait RuleShortcut {

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -220,6 +220,7 @@ where
         })
     }
 
+    #[must_use]
     pub(crate) fn map<M2>(self, f: fn(M) -> M2) -> RuleList<M2>
     where
         M2: 'static,

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -223,16 +223,21 @@ where
         })
     }
 
-    // pub(crate) fn map<M2>(mut self) -> RuleList<M2> where M2: Clone + 'static + Into<M> {
-    //     let list = self.list.into_iter().map(|endpoint| -> ErasedRule<M2> {
-    //       endpoint.map()
-    //     }).collect();
+    pub(crate) fn map<M2>(self, f: fn(M) -> M2) -> RuleList<M2>
+    where
+        M2: 'static,
+    {
+        let list = self
+            .list
+            .into_iter()
+            .map(|endpoint| endpoint.map(f))
+            .collect();
 
-    //     RuleList{
-    //       list,
-    //       is_bail: self.is_bail,
-    //     }
-    // }
+        RuleList {
+            list,
+            is_bail: self.is_bail,
+        }
+    }
 }
 
 pub trait IntoRuleList<M> {

--- a/src/rule/test.rs
+++ b/src/rule/test.rs
@@ -1,16 +1,1 @@
-use super::Message;
 
-#[test]
-fn test_message_serialize() {
-    let msg = Message::new(10, "hello world".into());
-    let json = serde_json::to_string(&msg).unwrap();
-    assert_eq!(json, r#"{"code":10,"content":"hello world"}"#);
-
-    let msg = Message::from_code(10);
-    let json = serde_json::to_string(&msg).unwrap();
-    assert_eq!(json, "10");
-
-    let msg = Message::from_content("hello".into());
-    let json = serde_json::to_string(&msg).unwrap();
-    assert_eq!(json, r#""hello""#);
-}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use valitron::{
     available::{Required, StartWith},
-    custom, Message, RuleExt, Validator, Value,
+    custom, RuleExt, Validator, Value,
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -37,13 +37,14 @@ fn test_validator() {
         res.get("age").unwrap()[0],
         "age should be between 25 and 45".into()
     );
-    assert_eq!(res.get("weight").unwrap()[0], Message::from_code(100),);
+    assert_eq!(
+        res.get("weight").unwrap()[0],
+        "weight should be between 40 and 80".into(),
+    );
     assert_eq!(
         res.get("name").unwrap()[0],
         "name should be starts with `hello`".into(),
     );
-
-    //println!("{res:?}");
 }
 
 fn age_limit(n: &mut u8) -> Result<(), String> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -46,21 +46,21 @@ fn test_validator() {
     //println!("{res:?}");
 }
 
-fn age_limit(n: &mut u8) -> Result<(), &'static str> {
+fn age_limit(n: &mut u8) -> Result<(), String> {
     if *n >= 25 && *n <= 45 {
         return Ok(());
     }
-    Err("age should be between 25 and 45")
+    Err("age should be between 25 and 45".into())
 }
 
-fn weight_limit(v: &mut Value) -> Result<(), u8> {
+fn weight_limit(v: &mut Value) -> Result<(), String> {
     if let Value::Float32(n) = v {
         let n = n.get();
         if n >= 40.0 && n <= 80.0 {
             return Ok(());
         }
     }
-    Err(100)
+    Err("weight should be between 40 and 80".into())
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use valitron::{
-    available::{Required, StartWith},
+    available::{Message, Required, StartWith},
     custom, RuleExt, Validator, Value,
 };
 
@@ -15,7 +15,7 @@ struct Person {
 
 #[test]
 fn test_validator() {
-    let validator = Validator::<String>::new()
+    let validator = Validator::<Message>::new()
         .rule("name", Required.and(StartWith("hello")))
         .rule("age", custom(age_limit))
         .rule("weight", custom(weight_limit))
@@ -34,27 +34,27 @@ fn test_validator() {
 
     assert!(res.len() == 3);
     assert_eq!(
-        res.get("age").unwrap()[0],
-        "age should be between 25 and 45".to_string()
+        res.get("age").unwrap()[0].to_string(),
+        "age should be between 25 and 45"
     );
     assert_eq!(
-        res.get("weight").unwrap()[0],
-        "weight should be between 40 and 80".to_string(),
+        res.get("weight").unwrap()[0].to_string(),
+        "weight should be between 40 and 80",
     );
     assert_eq!(
-        res.get("name").unwrap()[0],
-        "name should be starts with `hello`".to_string(),
+        res.get("name").unwrap()[0].to_string(),
+        "name should be starts with `hello`",
     );
 }
 
-fn age_limit(n: &mut u8) -> Result<(), String> {
+fn age_limit(n: &mut u8) -> Result<(), Message> {
     if *n >= 25 && *n <= 45 {
         return Ok(());
     }
-    Err("age should be between 25 and 45".to_string())
+    Err("age should be between 25 and 45".into())
 }
 
-fn weight_limit(v: &mut Value) -> Result<(), String> {
+fn weight_limit(v: &mut Value) -> Result<(), Message> {
     if let Value::Float32(n) = v {
         let n = n.get();
         if n >= 40.0 && n <= 80.0 {
@@ -66,7 +66,7 @@ fn weight_limit(v: &mut Value) -> Result<(), String> {
 
 #[test]
 fn test_has_tuple() {
-    let validator = Validator::<String>::new()
+    let validator = Validator::new()
         .rule(0, StartWith("hello"))
         .message([("0.start_with", "first item should be start with `hello`")]);
 
@@ -77,20 +77,20 @@ fn test_has_tuple() {
     assert!(res.len() == 1);
 
     assert_eq!(
-        res.get(0).unwrap()[0],
-        "first item should be start with `hello`".to_string()
+        res.get(0).unwrap()[0].to_string(),
+        "first item should be start with `hello`"
     );
 }
 
 #[test]
 fn test_has_array() {
-    let validator = Validator::<String>::new().rule([1], StartWith("hello"));
+    let validator = Validator::new().rule([1], StartWith("hello"));
 
     let res = validator.validate(vec!["foo", "bar"]).unwrap_err();
 
     assert!(res.len() == 1);
     assert_eq!(
-        res.get([1]).unwrap()[0],
-        "this field must be start with `hello`".to_string()
+        res.get([1]).unwrap()[0].to_string(),
+        "this field must be start with `hello`"
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,7 +15,7 @@ struct Person {
 
 #[test]
 fn test_validator() {
-    let validator = Validator::<Message>::new()
+    let validator = Validator::new()
         .rule("name", Required.and(StartWith("hello")))
         .rule("age", custom(age_limit))
         .rule("weight", custom(weight_limit))

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -35,15 +35,15 @@ fn test_validator() {
     assert!(res.len() == 3);
     assert_eq!(
         res.get("age").unwrap()[0],
-        "age should be between 25 and 45".into()
+        "age should be between 25 and 45".to_string()
     );
     assert_eq!(
         res.get("weight").unwrap()[0],
-        "weight should be between 40 and 80".into(),
+        "weight should be between 40 and 80".to_string(),
     );
     assert_eq!(
         res.get("name").unwrap()[0],
-        "name should be starts with `hello`".into(),
+        "name should be starts with `hello`".to_string(),
     );
 }
 
@@ -51,7 +51,7 @@ fn age_limit(n: &mut u8) -> Result<(), String> {
     if *n >= 25 && *n <= 45 {
         return Ok(());
     }
-    Err("age should be between 25 and 45".into())
+    Err("age should be between 25 and 45".to_string())
 }
 
 fn weight_limit(v: &mut Value) -> Result<(), String> {
@@ -78,7 +78,7 @@ fn test_has_tuple() {
 
     assert_eq!(
         res.get(0).unwrap()[0],
-        "first item should be start with `hello`".into()
+        "first item should be start with `hello`".to_string()
     );
 }
 
@@ -91,6 +91,6 @@ fn test_has_array() {
     assert!(res.len() == 1);
     assert_eq!(
         res.get([1]).unwrap()[0],
-        "this field must be start with `hello`".into()
+        "this field must be start with `hello`".to_string()
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,7 +15,7 @@ struct Person {
 
 #[test]
 fn test_validator() {
-    let validator = Validator::new()
+    let validator = Validator::<String>::new()
         .rule("name", Required.and(StartWith("hello")))
         .rule("age", custom(age_limit))
         .rule("weight", custom(weight_limit))
@@ -66,7 +66,7 @@ fn weight_limit(v: &mut Value) -> Result<(), String> {
 
 #[test]
 fn test_has_tuple() {
-    let validator = Validator::new()
+    let validator = Validator::<String>::new()
         .rule(0, StartWith("hello"))
         .message([("0.start_with", "first item should be start with `hello`")]);
 
@@ -84,7 +84,7 @@ fn test_has_tuple() {
 
 #[test]
 fn test_has_array() {
-    let validator = Validator::new().rule([1], StartWith("hello"));
+    let validator = Validator::<String>::new().rule([1], StartWith("hello"));
 
     let res = validator.validate(vec!["foo", "bar"]).unwrap_err();
 


### PR DESCRIPTION
# Intention

There are currently three types of message available:
- u8
- String
- both

`ValidatorError` is implemented `Serialize` ,when it covert to json, probability result:

- `{"field1":["message1","message2"]}`
- `{"field1":["message1",2]}`
- `{"field1":[1,2]}`

second result is type error.

# Scheme
## Enchance message [deprecated]
<details>
<summary>once validator support two message types</summary>

- support custom define
- support custom and using build-in rule, e.g.:

```rust
fn main() {
    let _validator = Validator::<MyMessage>::new()
        .rule("name", Required.and(StartWith("foo")))
        .message([
            ("name.required", MyMessage::NameRequierd),
            ("name.start_with", MyMessage::NameStartWith),
        ]);
}

#[derive(Clone)]
enum MyMessage {
    NameRequierd,
    NameStartWith,
    Undefined,
}
```
</details>

## Message converting

```rust
let validator1 = Validator::<Msg1>::new();
let validator2 = validator1.map(Msg2::from);

impl From<Msg1> for Msg2 {
   ...
}
```