### PR TITLE
feat(rule)!: name changed to const type

### DIFF
--- a/examples/enum_msg.rs
+++ b/examples/enum_msg.rs
@@ -35,12 +35,13 @@ struct Gt10;
 
 impl RuleShortcut for Gt10 {
     type Message = MyMessage;
-    fn name(&self) -> &'static str {
-        "gt10"
-    }
+
+    const NAME: &'static str = "gt10";
+
     fn message(&self) -> Self::Message {
         MyMessage::Gt10
     }
+
     fn call(&mut self, data: &mut Value) -> bool {
         data > 10_u8
     }
@@ -51,12 +52,13 @@ struct Lt20;
 
 impl RuleShortcut for Lt20 {
     type Message = MyMessage2;
-    fn name(&self) -> &'static str {
-        "gt10"
-    }
+
+    const NAME: &'static str = "lt20";
+
     fn message(&self) -> Self::Message {
         MyMessage2::Lt20
     }
+
     fn call(&mut self, data: &mut Value) -> bool {
         data < 20_u8
     }

--- a/examples/enum_msg_full.rs
+++ b/examples/enum_msg_full.rs
@@ -51,9 +51,7 @@ struct Gt10;
 impl RuleShortcut for Gt10 {
     type Message = MyMessage;
 
-    fn name(&self) -> &'static str {
-        "gt10"
-    }
+    const NAME: &'static str = "gt10";
 
     fn message(&self) -> Self::Message {
         MyMessage::Gt10

--- a/src/rule/available/confirm.rs
+++ b/src/rule/available/confirm.rs
@@ -48,11 +48,9 @@ impl<T: Debug> Debug for Confirm<T> {
     }
 }
 
-impl<T> Confirm<T> {
-    fn name_in(&self) -> &'static str {
-        "confirm"
-    }
+const NAME: &'static str = "confirm";
 
+impl<T> Confirm<T> {
     pub const fn as_ref(&self) -> Confirm<&T> {
         let Confirm(ref t) = self;
         Confirm(t)
@@ -84,9 +82,7 @@ where
 impl RuleShortcut for Confirm<String> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()
@@ -106,9 +102,7 @@ impl RuleShortcut for Confirm<String> {
 impl RuleShortcut for Confirm<&str> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()

--- a/src/rule/available/contains.rs
+++ b/src/rule/available/contains.rs
@@ -45,11 +45,9 @@ impl<T: Debug> Debug for Contains<T> {
     }
 }
 
-impl<T> Contains<T> {
-    fn name_in(&self) -> &'static str {
-        "contains"
-    }
+const NAME: &'static str = "contains";
 
+impl<T> Contains<T> {
     pub const fn as_ref(&self) -> Contains<&T> {
         let Contains(ref t) = self;
         Contains(t)
@@ -73,9 +71,7 @@ where
 impl RuleShortcut for Contains<&str> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()
@@ -92,9 +88,7 @@ impl RuleShortcut for Contains<&str> {
 impl RuleShortcut for Contains<String> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()
@@ -111,9 +105,7 @@ impl RuleShortcut for Contains<String> {
 impl RuleShortcut for Contains<char> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()

--- a/src/rule/available/end_with.rs
+++ b/src/rule/available/end_with.rs
@@ -45,11 +45,9 @@ impl<T: Debug> Debug for EndsWith<T> {
     }
 }
 
-impl<T> EndsWith<T> {
-    fn name_in(&self) -> &'static str {
-        "end_with"
-    }
+const NAME: &'static str = "end_with";
 
+impl<T> EndsWith<T> {
     pub const fn as_ref(&self) -> EndsWith<&T> {
         let EndsWith(ref t) = self;
         EndsWith(t)
@@ -73,9 +71,7 @@ where
 impl RuleShortcut for EndsWith<&str> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()
@@ -92,9 +88,7 @@ impl RuleShortcut for EndsWith<&str> {
 impl RuleShortcut for EndsWith<String> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()
@@ -111,9 +105,7 @@ impl RuleShortcut for EndsWith<String> {
 impl RuleShortcut for EndsWith<char> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()

--- a/src/rule/available/length.rs
+++ b/src/rule/available/length.rs
@@ -55,11 +55,9 @@ impl<T: Debug> Debug for Length<T> {
     }
 }
 
-impl<T> Length<T> {
-    fn name_in(&self) -> &'static str {
-        "length"
-    }
+const NAME: &'static str = "length";
 
+impl<T> Length<T> {
     fn message_in(&self) -> Message {
         Message::new(super::MessageKind::Length)
     }
@@ -80,9 +78,9 @@ where
     T: RangeBounds<usize>,
 {
     type Message = Message;
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+
+    const NAME: &'static str = NAME;
+
     fn message(&self) -> Self::Message {
         self.message_in()
     }

--- a/src/rule/available/range.rs
+++ b/src/rule/available/range.rs
@@ -43,16 +43,14 @@ impl<T: Debug, Num> Debug for Range<T, Num> {
     }
 }
 
+const NAME: &'static str = "range";
+
 impl<T, Num> Range<T, Num> {
     pub fn new(value: T) -> Self {
         Self {
             value,
             _marker: PhantomData,
         }
-    }
-
-    fn name_in(&self) -> &'static str {
-        "range"
     }
 
     fn message_in(&self) -> Message {
@@ -67,12 +65,13 @@ macro_rules! impl_range {
             T: RangeBounds<$ty>,
         {
             type Message = Message;
-            fn name(&self) -> &'static str {
-                self.name_in()
-            }
+
+            const NAME: &'static str = NAME;
+
             fn message(&self) -> Self::Message {
                 self.message_in()
             }
+
             fn call(&mut self, data: &mut Value) -> bool {
                 match data {
                     Value::$val(n) => self.value.contains(n),
@@ -98,12 +97,13 @@ where
     T: RangeBounds<f32> + Clone + 'static,
 {
     type Message = Message;
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+
+    const NAME: &'static str = NAME;
+
     fn message(&self) -> Self::Message {
         self.message_in()
     }
+
     fn call(&mut self, data: &mut Value) -> bool {
         match data {
             Value::Float32(f) => self.value.contains(f.as_ref()),
@@ -117,12 +117,13 @@ where
     T: RangeBounds<f64> + Clone + 'static,
 {
     type Message = Message;
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+
+    const NAME: &'static str = NAME;
+
     fn message(&self) -> Self::Message {
         self.message_in()
     }
+
     fn call(&mut self, data: &mut Value) -> bool {
         match data {
             Value::Float64(f) => self.value.contains(f.as_ref()),

--- a/src/rule/available/required.rs
+++ b/src/rule/available/required.rs
@@ -51,12 +51,12 @@ use crate::{RuleShortcut, Value};
 #[derive(Clone, Debug)]
 pub struct Required;
 
+const NAME: &'static str = "required";
+
 impl RuleShortcut for Required {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        "required"
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         Message::new(super::MessageKind::Required)

--- a/src/rule/available/start_with.rs
+++ b/src/rule/available/start_with.rs
@@ -52,11 +52,9 @@ impl<T: Debug> Debug for StartWith<T> {
     }
 }
 
-impl<T> StartWith<T> {
-    fn name_in(&self) -> &'static str {
-        "start_with"
-    }
+const NAME: &'static str = "start_with";
 
+impl<T> StartWith<T> {
     pub const fn as_ref(&self) -> StartWith<&T> {
         let StartWith(ref t) = self;
         StartWith(t)
@@ -80,9 +78,7 @@ where
 impl RuleShortcut for StartWith<&str> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()
@@ -99,9 +95,7 @@ impl RuleShortcut for StartWith<&str> {
 impl RuleShortcut for StartWith<String> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()
@@ -118,9 +112,7 @@ impl RuleShortcut for StartWith<String> {
 impl RuleShortcut for StartWith<char> {
     type Message = Message;
 
-    fn name(&self) -> &'static str {
-        self.name_in()
-    }
+    const NAME: &'static str = NAME;
 
     fn message(&self) -> Self::Message {
         self.message_in()

--- a/src/rule/available/trim.rs
+++ b/src/rule/available/trim.rs
@@ -27,8 +27,12 @@ use super::Message;
 #[derive(Clone)]
 pub struct Trim;
 
+const NAME: &'static str = "trim";
+
 impl RuleShortcut for Trim {
     type Message = Message;
+
+    const NAME: &'static str = NAME;
 
     fn call(&mut self, data: &mut crate::Value) -> bool {
         match data {
@@ -41,10 +45,6 @@ impl RuleShortcut for Trim {
 
     fn message(&self) -> Self::Message {
         Message::new(super::MessageKind::Trim)
-    }
-
-    fn name(&self) -> &'static str {
-        "trim"
     }
 }
 

--- a/src/rule/boxed.rs
+++ b/src/rule/boxed.rs
@@ -90,7 +90,7 @@ where
     }
 
     fn name(&self) -> &'static str {
-        self.handler.name()
+        H::THE_NAME
     }
 }
 

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -8,9 +8,7 @@
 //! impl RuleShortcut for Gt10 {
 //!     type Message = &'static str;
 //!
-//!     fn name(&self) -> &'static str {
-//!         "gt10"
-//!     }
+//!     const NAME: &'static str = "gt10";
 //!
 //!     fn message(&self) -> Self::Message {
 //!         "the number should be greater than 10"
@@ -46,9 +44,7 @@ mod test;
 /// impl Rule<()> for Gt10 {
 ///     type Message = &'static str;
 ///
-///     fn name(&self) -> &'static str {
-///         "gt10"
-///     }
+///     const THE_NAME: &'static str = "gt10";
 ///
 ///     fn call(&mut self, data: &mut ValueMap) -> Result<(), Self::Message> {
 ///         if data.current().unwrap() > &10 {
@@ -70,7 +66,7 @@ pub trait Rule<T>: 'static + Sized + Clone {
     /// Named rule type, used to distinguish between different rules.
     ///
     /// allow `a-z` | `A-Z` | `0-9` | `_` composed string, and not start with `0-9`
-    fn name(&self) -> &'static str;
+    const THE_NAME: &'static str;
 
     /// Rule specific implementation, data is gived type all field's value, and current field index.
     ///
@@ -337,9 +333,9 @@ mod test_regster {
 
     impl RuleShortcut for Gt10 {
         type Message = u8;
-        fn name(&self) -> &'static str {
-            "gt10"
-        }
+
+        const NAME: &'static str = "gt10";
+
         fn message(&self) -> Self::Message {
             1
         }
@@ -350,6 +346,9 @@ mod test_regster {
 
     #[test]
     fn test() {
+        assert_eq!(Gt10::NAME, "gt10");
+        assert_eq!(Confirm::<&str>::NAME, "confirm");
+
         register(Required);
         register(Required.custom(hander2));
         register(Required.custom(hander));
@@ -384,7 +383,7 @@ pub trait RuleShortcut {
     /// Named rule type, used to distinguish different rules
     ///
     /// allow `a-z` | `A-Z` | `0-9` | `_` composed string, and not start with `0-9`
-    fn name(&self) -> &'static str;
+    const NAME: &'static str;
 
     /// Default rule error message, when validate fails, return the message to user
     fn message(&self) -> Self::Message;
@@ -410,9 +409,8 @@ where
 {
     type Message = T::Message;
 
-    fn name(&self) -> &'static str {
-        self.name()
-    }
+    const THE_NAME: &'static str = T::NAME;
+
     /// Rule specific implementation, data is gived type all field's value, and current field index.
     fn call(&mut self, data: &mut ValueMap) -> Result<(), Self::Message> {
         if self.call_with_relate(data) {
@@ -429,11 +427,11 @@ where
     V: FromValue,
 {
     type Message = M;
+
+    const THE_NAME: &'static str = "custom";
+
     fn call(&mut self, data: &mut ValueMap) -> Result<(), Self::Message> {
         let val = V::from_value(data).expect("argument type can not be matched");
         self.clone()(val)
-    }
-    fn name(&self) -> &'static str {
-        "custom"
     }
 }


### PR DESCRIPTION
# Detail

remove name method in Rule trait, and add a const replace it.

```diff
trait Rule<M> {
      ...
-    fn name(&self) -> &'static str {
-         "[rule name]"
-    }
+    const NAME: &'static str = "[rule name]";
}
```

# Motive

When creating validation messages using rule names, it should to reduces errors, and not need instancing it.

```rust
fn to_msg(name: &'static str) -> NewMessage{
    match name {
         Required::NAME => NewMessage::Required,
         Range::NAME => NewMessage::Range,
         ...
    }
}
```